### PR TITLE
Fehler with Link

### DIFF
--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     );
 
     const urlToHelferansichtPage = new URL(
-      `/helferansicht?einsatzId=${encodeURIComponent(einsatz.id)}`,
+      `/helferansicht?einsatz=${encodeURIComponent(einsatz.id)}`,
       baseUrl
     ).toString();
 


### PR DESCRIPTION
This pull request makes a small update to the URL parameter used when generating the `helferansicht` page link in the calendar API route. The parameter name in the query string is changed from `einsatzId` to `einsatz` to ensure consistency with the rest of the application. ([src/app/api/calendar/[token]/route.tsL65-R65](diffhunk://#diff-5662a39cfb10f3dda168138737979fea6cc8643702577788292f61e0a35793fbL65-R65))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query parameter naming in the helper view link to ensure proper system integration and data transmission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->