### PR TITLE
Added maxDuration, probably and hopefully needed for vercel

### DIFF
--- a/src/app/api/events/[orgId]/route.ts
+++ b/src/app/api/events/[orgId]/route.ts
@@ -5,7 +5,7 @@ import { authOptions } from '@/lib/auth.config';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-
+export const maxDuration = 60;
 interface ConnectedMessage {
   type: 'connected';
   orgId: string;


### PR DESCRIPTION
This pull request introduces a small configuration update to the events API route. The maximum duration for the route's execution has been set to 60 seconds to better control resource usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API timeout configuration to improve system stability and ensure consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->