### PR TITLE
Clarify back wording in nested settings dialogs

### DIFF
--- a/src/app/(pages)/(main)/settings/vorlage/[templateId]/page.tsx
+++ b/src/app/(pages)/(main)/settings/vorlage/[templateId]/page.tsx
@@ -8,5 +8,5 @@ export default function EditTemplatePage() {
   const templateId =
     typeof params.templateId === 'string' ? params.templateId : null;
 
-  return <TemplateForm templateId={templateId} />;
+  return <TemplateForm templateId={templateId} cancelLabel="Zurück" />;
 }

--- a/src/app/(pages)/(main)/settings/vorlage/neu/page.tsx
+++ b/src/app/(pages)/(main)/settings/vorlage/neu/page.tsx
@@ -23,6 +23,10 @@ export default function NewTemplatePage() {
   }
 
   return (
-    <TemplateForm orgId={orgId} backHref={`/settings/org/${orgId}#vorlagen`} />
+    <TemplateForm
+      orgId={orgId}
+      backHref={`/settings/org/${orgId}#vorlagen`}
+      cancelLabel="Zurück"
+    />
   );
 }

--- a/src/components/settings/PageHeader.tsx
+++ b/src/components/settings/PageHeader.tsx
@@ -11,6 +11,7 @@ interface PageHeaderProps {
   isSaving?: boolean;
   onCancel?: () => void;
   cancelHref?: string;
+  cancelLabel?: string;
 }
 
 export function PageHeader({
@@ -20,6 +21,7 @@ export function PageHeader({
   isSaving = false,
   onCancel,
   cancelHref,
+  cancelLabel = 'Schließen',
 }: PageHeaderProps) {
   const router = useRouter();
 
@@ -52,7 +54,7 @@ export function PageHeader({
             className="min-h-10 min-w-11 touch-manipulation sm:min-h-9"
             type="button"
           >
-            Schließen
+            {cancelLabel}
             <span className="ml-2 hidden sm:inline">
               <Kbd>ESC</Kbd>
             </span>

--- a/src/components/settings/UserProfileDialog.tsx
+++ b/src/components/settings/UserProfileDialog.tsx
@@ -543,7 +543,7 @@ export function UserProfileDialog({
               Fehler beim Laden der Benutzerdaten
             </p>
             <Button variant="secondary" onClick={onClose}>
-              Schließen
+              Zurück
             </Button>
           </CardContent>
         </Card>
@@ -577,7 +577,7 @@ export function UserProfileDialog({
           <div className="shrink-0 bg-white px-4 py-3 md:px-6 md:py-4">
             <div className="flex items-center justify-end gap-2">
               <Button variant="outline" size="sm" onClick={handleClose}>
-                {hasChanges ? 'Abbrechen' : 'Schließen'}
+                {hasChanges ? 'Abbrechen' : 'Zurück'}
               </Button>
               <Button
                 size="sm"

--- a/src/components/template/TemplateForm.tsx
+++ b/src/components/template/TemplateForm.tsx
@@ -92,12 +92,14 @@ interface TemplateFormProps {
   templateId?: string | null;
   /** Optional for edit – derived from template.org_id when template is loaded */
   backHref?: string;
+  cancelLabel?: string;
 }
 
 export function TemplateForm({
   orgId: orgIdProp,
   templateId,
   backHref: backHrefProp,
+  cancelLabel = 'Schließen',
 }: TemplateFormProps) {
   const router = useRouter();
   const isEdit = !!templateId;
@@ -713,6 +715,7 @@ export function TemplateForm({
       onSave={() => form.handleSubmit(onSubmit)()}
       isSaving={isSaving}
       onCancel={handleCancel}
+      cancelLabel={cancelLabel}
     />
   );
 
@@ -1405,7 +1408,7 @@ export function TemplateForm({
         </div>
         <div>
           <Button variant="ghost" onClick={handleCancel}>
-            Schließen (ESC)
+            {cancelLabel} (ESC)
           </Button>
           <Button
             onClick={() => form.handleSubmit(onSubmit)()}


### PR DESCRIPTION
## Summary
- switch settings template pages to use `Zurück` for the primary back action
- make the shared page header accept a configurable cancel label
- update the Nutzerprofil dialog to use `Zurück` when leaving the settings overlay while keeping `Abbrechen` for unsaved changes

## Testing
- not run (workspace install/typecheck is currently blocked by missing local env/dependency setup in this worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cancel buttons now display contextually appropriate labels across template management and profile screens, improving navigation clarity.

* **Bug Fixes**
  * Updated button labels from "Close" to "Back" in template editing and user profile management to better reflect the navigation action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->