### PR TITLE
Strike through past days 

### DIFF
--- a/src/components/event-calendar/event-calendar.tsx
+++ b/src/components/event-calendar/event-calendar.tsx
@@ -11,7 +11,6 @@ import {
   endOfWeek,
   format,
   isSameMonth,
-  startOfDay,
   startOfWeek,
   subMonths,
   subWeeks,
@@ -56,6 +55,7 @@ import { useEventDialog } from '@/hooks/use-event-dialog';
 import { useOrganizationTerminology } from '@/hooks/use-organization-terminology';
 import { useOrganizations } from '@/features/organization/hooks/use-organization-queries';
 import { useEinsaetzeForAgenda } from '@/features/einsatz/hooks/useEinsatzQueries';
+import { useTodayStart } from '@/components/event-calendar/hooks/use-today-start';
 
 export interface EventCalendarProps {
   events?: CalendarEvent[];
@@ -97,6 +97,7 @@ export function EventCalendar({
   mode,
   activeOrgId,
 }: EventCalendarProps) {
+  const todayStart = useTodayStart();
   const [internalDate, setInternalDate] = useState(new Date());
   const currentDate = currentDateProp ?? internalDate;
   const setCurrentDate = setCurrentDateProp ?? setInternalDate;
@@ -312,7 +313,7 @@ export function EventCalendar({
   };
 
   const viewTitle = useMemo(() => {
-    const isPastCurrentDay = startOfDay(currentDate) < startOfDay(new Date());
+    const isPastCurrentDay = currentDate < todayStart;
 
     if (view === 'month') {
       return format(currentDate, 'MMMM yyyy', { locale: de });
@@ -362,7 +363,7 @@ export function EventCalendar({
     } else {
       return format(currentDate, 'MMMM yyyy', { locale: de });
     }
-  }, [currentDate, view]);
+  }, [currentDate, todayStart, view]);
 
   return (
     <div

--- a/src/components/event-calendar/hooks/use-today-start.ts
+++ b/src/components/event-calendar/hooks/use-today-start.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { addDays, startOfDay } from 'date-fns';
+
+function getTodayStart() {
+  return startOfDay(new Date());
+}
+
+export function useTodayStart() {
+  const [todayStart, setTodayStart] = useState<Date>(() => getTodayStart());
+
+  useEffect(() => {
+    const scheduleNextUpdate = () => {
+      const nextMidnight = startOfDay(addDays(new Date(), 1));
+      const timeout = nextMidnight.getTime() - Date.now();
+
+      return window.setTimeout(() => {
+        setTodayStart(getTodayStart());
+      }, timeout);
+    };
+
+    const timeoutId = scheduleNextUpdate();
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [todayStart]);
+
+  return todayStart;
+}

--- a/src/components/event-calendar/month-view.tsx
+++ b/src/components/event-calendar/month-view.tsx
@@ -7,7 +7,6 @@ import {
   endOfMonth,
   endOfWeek,
   format,
-  startOfDay,
   isSameDay,
   isSameMonth,
   isToday,
@@ -35,6 +34,7 @@ import {
   DefaultStartHour,
   MaxEventsPerCellInMonthView,
 } from '@/components/event-calendar/constants';
+import { useTodayStart } from '@/components/event-calendar/hooks/use-today-start';
 import { CalendarMode } from './types';
 
 interface MonthViewProps {
@@ -54,6 +54,8 @@ export function MonthView({
   mode,
   onEventConfirm,
 }: MonthViewProps) {
+  const todayStart = useTodayStart();
+
   const days = useMemo(() => {
     const monthStart = startOfMonth(currentDate);
     const monthEnd = endOfMonth(monthStart);
@@ -163,7 +165,7 @@ export function MonthView({
               });
 
               const isCurrentMonth = isSameMonth(day, currentDate);
-              const isPastDay = startOfDay(day) < startOfDay(new Date());
+              const isPastDay = day < todayStart;
               const cellId = `month-cell-${day.toISOString()}`;
               const allEvents = getAllEventsForDay(events, day);
 

--- a/src/components/event-calendar/week-view.tsx
+++ b/src/components/event-calendar/week-view.tsx
@@ -20,6 +20,7 @@ import {
 import { de } from 'date-fns/locale';
 
 import { cn } from '@/lib/utils';
+import { useTodayStart } from '@/components/event-calendar/hooks/use-today-start';
 import {
   DraggableEvent,
   DroppableCell,
@@ -61,6 +62,8 @@ export function WeekView({
   mode,
   onEventConfirm,
 }: WeekViewProps) {
+  const todayStart = useTodayStart();
+
   const days = useMemo(() => {
     const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 });
     const weekEnd = endOfWeek(currentDate, { weekStartsOn: 1 });
@@ -334,9 +337,7 @@ export function WeekView({
               {format(day, 'E', { locale: de })[0]}{' '}
               <span
                 className={
-                  startOfDay(day) < startOfDay(new Date())
-                    ? 'line-through'
-                    : undefined
+                  startOfDay(day) < todayStart ? 'line-through' : undefined
                 }
               >
                 {format(day, 'd')}
@@ -346,9 +347,7 @@ export function WeekView({
               {format(day, 'EEE ', { locale: de })}
               <span
                 className={
-                  startOfDay(day) < startOfDay(new Date())
-                    ? 'line-through'
-                    : undefined
+                  startOfDay(day) < todayStart ? 'line-through' : undefined
                 }
               >
                 {format(day, 'dd')}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Past dates in the event calendar now show strikethrough styling across day, week and month views for clearer at-a-glance distinction.
  * Calendar headers and view titles now consistently reflect past-day styling.
  * Styling updates automatically refresh at local midnight so past-day indicators remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->