### PR TITLE
fix styling in lv filter: filter function name wrong width

### DIFF
--- a/src/components/data-table/components/data-table-filter-menu.tsx
+++ b/src/components/data-table/components/data-table-filter-menu.tsx
@@ -510,7 +510,7 @@ function DataTableFilterItem<TData>({
         >
           <SelectTrigger
             aria-controls={operatorListboxId}
-            className="h-8 rounded-none border-r-0 px-2.5 lowercase data-size:h-8 [&_svg]:hidden"
+            className="h-8 w-auto flex-none rounded-none border-r-0 px-2.5 lowercase data-size:h-8 [&>span]:flex-none [&_svg]:hidden"
           >
             <SelectValue placeholder={filter.operator} />
           </SelectTrigger>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and sizing of the filter operator dropdown in the data table for better visual consistency and display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->