### PR TITLE
Fix Einsatz time offset across persistence, cache and realtime

### DIFF
--- a/src/components/event-calendar/calendar-client.tsx
+++ b/src/components/event-calendar/calendar-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { toast } from 'sonner';
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useMemo, useState } from 'react';
 import { addMonths, subMonths } from 'date-fns';
 
 import { EventCalendar } from '@/components/event-calendar';
@@ -31,6 +31,7 @@ import type {
 } from '@/features/einsatz/types';
 import { useEventDialogFromContext } from '@/contexts/EventDialogContext';
 import type { UserPropertyWithField } from '@/features/user_properties/user_property-dal';
+import { normalizeCalendarDateValue } from '@/features/einsatz/datetime';
 
 interface UserWithProperties {
   id: string;
@@ -174,8 +175,24 @@ export default function Component({ mode }: { mode: CalendarMode }) {
   } = useEinsaetzeForCalendar(activeOrgId, currentDate);
   const prefetchEinsaetzeForCalendar =
     usePrefetchEinsaetzeForCalendar(activeOrgId);
-  const events = calendarData?.events;
-  const detailedEinsaetze = calendarData?.detailedEinsaetze ?? [];
+  const events = useMemo(
+    () =>
+      (calendarData?.events ?? []).map((event) => ({
+        ...event,
+        start: normalizeCalendarDateValue(event.start) ?? event.start,
+        end: normalizeCalendarDateValue(event.end) ?? event.end,
+      })),
+    [calendarData?.events]
+  );
+  const detailedEinsaetze = useMemo(
+    () =>
+      (calendarData?.detailedEinsaetze ?? []).map((einsatz) => ({
+        ...einsatz,
+        start: normalizeCalendarDateValue(einsatz.start) ?? einsatz.start,
+        end: normalizeCalendarDateValue(einsatz.end) ?? einsatz.end,
+      })),
+    [calendarData?.detailedEinsaetze]
+  );
   const cachedDetailedEinsatz =
     typeof selectedEinsatz === 'string'
       ? detailedEinsaetze.find((e) => e.id === selectedEinsatz)
@@ -368,7 +385,7 @@ export default function Component({ mode }: { mode: CalendarMode }) {
     return <div>Fehler beim Laden der Einsätze: {msg}</div>;
   }
 
-  const calendarEvents = calendarData?.events ?? [];
+  const calendarEvents = events ?? [];
   return (
     <>
       <EventCalendar

--- a/src/features/einsatz/datetime.test.ts
+++ b/src/features/einsatz/datetime.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   dbTimestampToCalendarDate,
   normalizeDateRangeFromDb,
+  normalizeCalendarDateValue,
   parseCalendarDateTimeString,
   prismaTimestampToCalendarDate,
 } from './datetime';
@@ -102,5 +103,15 @@ describe('datetime normalization', () => {
     expect(parsed).toBeDefined();
     expect(parsed?.getHours()).toBe(10);
     expect(parsed?.getMinutes()).toBe(15);
+  });
+
+  it('normalisiert Calendar-Date-Werte tolerant für Date-Instanzen aus dem Cache', () => {
+    const normalized = normalizeCalendarDateValue(
+      new Date(2026, 3, 9, 14, 30, 0, 0)
+    );
+
+    expect(normalized).toBeDefined();
+    expect(normalized?.getHours()).toBe(14);
+    expect(normalized?.getMinutes()).toBe(30);
   });
 });

--- a/src/features/einsatz/datetime.ts
+++ b/src/features/einsatz/datetime.ts
@@ -13,6 +13,8 @@ type TimeDefaultRange = Pick<
   'default_starttime' | 'default_endtime'
 >;
 
+type CalendarDateValue = Date | string | null | undefined;
+
 /**
  * Realtime / wire payloads expose these calendar timestamps as UTC-like instants while the
  * column type is "timestamp without time zone". For calendar UX we treat them as floating
@@ -64,6 +66,20 @@ export function parseCalendarDateTimeString(
   return Number.isNaN(parsedDate.getTime())
     ? undefined
     : dbTimestampToCalendarDate(parsedDate);
+}
+
+export function normalizeCalendarDateValue(
+  value: CalendarDateValue
+): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return prismaTimestampToCalendarDate(value);
+  }
+
+  return parseCalendarDateTimeString(value);
 }
 
 /**


### PR DESCRIPTION
## Zusammenfassung
Dieser PR behebt den `-2h`-Versatz bei Einsatzzeiten in Persistenz, lokalem Cache und Realtime-Updates.

## Änderungen
- trennt die Behandlung von Prisma-Zeitwerten und Realtime-/Wire-Zeitstrings für `timestamp without time zone`
- parst Realtime-Strings ohne Zeitzonenangabe als lokale Wandzeit
- unterstützt Mikrosekunden aus `timestamp(6)` / `time(6)` deterministisch bis auf Millisekunden gekürzt
- verwendet im Kalender-Mapping und vor dem Rendern konsistent normalisierte Start-/Endzeiten, damit auch kurzlebige Cachezustände keinen `-2h`-Flash zeigen
- ergänzt Regressionstests für Prisma-, Wire-, Realtime- und Cache-Zeitpfade

## Verifikation
- `pnpm test:run src/features/einsatz/datetime.test.ts`
- `pnpm test:run src/features/einsatz/dal-einsatz.test.ts`
- `pnpm test:run src/components/event-calendar/calendar-client.test.tsx`
- `pnpm exec tsc --noEmit`