### PR TITLE
Revert "Fix Einsatz time offset across persistence, cache and realtime"

### DIFF
--- a/src/components/event-calendar/calendar-client.tsx
+++ b/src/components/event-calendar/calendar-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { toast } from 'sonner';
-import { useEffect, useCallback, useMemo, useState } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { addMonths, subMonths } from 'date-fns';
 
 import { EventCalendar } from '@/components/event-calendar';
@@ -31,7 +31,6 @@ import type {
 } from '@/features/einsatz/types';
 import { useEventDialogFromContext } from '@/contexts/EventDialogContext';
 import type { UserPropertyWithField } from '@/features/user_properties/user_property-dal';
-import { normalizeCalendarDateValue } from '@/features/einsatz/datetime';
 
 interface UserWithProperties {
   id: string;
@@ -175,24 +174,8 @@ export default function Component({ mode }: { mode: CalendarMode }) {
   } = useEinsaetzeForCalendar(activeOrgId, currentDate);
   const prefetchEinsaetzeForCalendar =
     usePrefetchEinsaetzeForCalendar(activeOrgId);
-  const events = useMemo(
-    () =>
-      (calendarData?.events ?? []).map((event) => ({
-        ...event,
-        start: normalizeCalendarDateValue(event.start) ?? event.start,
-        end: normalizeCalendarDateValue(event.end) ?? event.end,
-      })),
-    [calendarData?.events]
-  );
-  const detailedEinsaetze = useMemo(
-    () =>
-      (calendarData?.detailedEinsaetze ?? []).map((einsatz) => ({
-        ...einsatz,
-        start: normalizeCalendarDateValue(einsatz.start) ?? einsatz.start,
-        end: normalizeCalendarDateValue(einsatz.end) ?? einsatz.end,
-      })),
-    [calendarData?.detailedEinsaetze]
-  );
+  const events = calendarData?.events;
+  const detailedEinsaetze = calendarData?.detailedEinsaetze ?? [];
   const cachedDetailedEinsatz =
     typeof selectedEinsatz === 'string'
       ? detailedEinsaetze.find((e) => e.id === selectedEinsatz)
@@ -385,7 +368,7 @@ export default function Component({ mode }: { mode: CalendarMode }) {
     return <div>Fehler beim Laden der Einsätze: {msg}</div>;
   }
 
-  const calendarEvents = events ?? [];
+  const calendarEvents = calendarData?.events ?? [];
   return (
     <>
       <EventCalendar

--- a/src/features/einsatz/datetime.test.ts
+++ b/src/features/einsatz/datetime.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   dbTimestampToCalendarDate,
   normalizeDateRangeFromDb,
-  normalizeCalendarDateValue,
   parseCalendarDateTimeString,
   prismaTimestampToCalendarDate,
 } from './datetime';
@@ -103,15 +102,5 @@ describe('datetime normalization', () => {
     expect(parsed).toBeDefined();
     expect(parsed?.getHours()).toBe(10);
     expect(parsed?.getMinutes()).toBe(15);
-  });
-
-  it('normalisiert Calendar-Date-Werte tolerant für Date-Instanzen aus dem Cache', () => {
-    const normalized = normalizeCalendarDateValue(
-      new Date(2026, 3, 9, 14, 30, 0, 0)
-    );
-
-    expect(normalized).toBeDefined();
-    expect(normalized?.getHours()).toBe(14);
-    expect(normalized?.getMinutes()).toBe(30);
   });
 });

--- a/src/features/einsatz/datetime.ts
+++ b/src/features/einsatz/datetime.ts
@@ -13,8 +13,6 @@ type TimeDefaultRange = Pick<
   'default_starttime' | 'default_endtime'
 >;
 
-type CalendarDateValue = Date | string | null | undefined;
-
 /**
  * Realtime / wire payloads expose these calendar timestamps as UTC-like instants while the
  * column type is "timestamp without time zone". For calendar UX we treat them as floating
@@ -66,20 +64,6 @@ export function parseCalendarDateTimeString(
   return Number.isNaN(parsedDate.getTime())
     ? undefined
     : dbTimestampToCalendarDate(parsedDate);
-}
-
-export function normalizeCalendarDateValue(
-  value: CalendarDateValue
-): Date | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  if (value instanceof Date) {
-    return prismaTimestampToCalendarDate(value);
-  }
-
-  return parseCalendarDateTimeString(value);
 }
 
 /**


### PR DESCRIPTION
Reverts yenidede/einsatzplaner#418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal calendar data handling by removing redundant normalization logic while preserving existing functionality.
  * Streamlined component data flow and reduced unnecessary transformations in the calendar module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->