### PR TITLE
-2 hrs possibly fixed

### DIFF
--- a/src/features/einsatz/datetime.test.ts
+++ b/src/features/einsatz/datetime.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  calendarDateToDbTimestamp,
   dbTimestampToCalendarDate,
+  normalizeDateRangeForDb,
   normalizeDateRangeFromDb,
   parseCalendarDateTimeString,
   prismaTimestampToCalendarDate,
@@ -109,5 +111,26 @@ describe('datetime normalization', () => {
     expect(parsed).toBeDefined();
     expect(parsed?.getHours()).toBe(expectedHour);
     expect(parsed?.getMinutes()).toBe(expectedMinute);
+  });
+
+  it('preserves the original instant when converting calendar dates for DB writes', () => {
+    const calendarDate = new Date(2026, 3, 23, 18, 15, 0, 123);
+
+    const dbDate = calendarDateToDbTimestamp(calendarDate);
+
+    expect(dbDate.getTime()).toBe(calendarDate.getTime());
+    expect(dbDate.toISOString()).toBe(calendarDate.toISOString());
+  });
+
+  it('normalizes date ranges for DB without introducing timezone drift', () => {
+    const range = {
+      start: new Date(2026, 3, 23, 18, 15, 0, 0),
+      end: new Date(2026, 3, 23, 20, 15, 0, 0),
+    };
+
+    const normalized = normalizeDateRangeForDb(range);
+
+    expect(normalized.start.getTime()).toBe(range.start.getTime());
+    expect(normalized.end.getTime()).toBe(range.end.getTime());
   });
 });

--- a/src/features/einsatz/datetime.test.ts
+++ b/src/features/einsatz/datetime.test.ts
@@ -113,24 +113,23 @@ describe('datetime normalization', () => {
     expect(parsed?.getMinutes()).toBe(expectedMinute);
   });
 
-  it('preserves the original instant when converting calendar dates for DB writes', () => {
-    const calendarDate = new Date(2026, 3, 23, 18, 15, 0, 123);
+  it('converts calendar instants to Vienna wall-clock for DB writes', () => {
+    const calendarDate = new Date('2026-07-01T13:15:00.123Z');
 
     const dbDate = calendarDateToDbTimestamp(calendarDate);
 
-    expect(dbDate.getTime()).toBe(calendarDate.getTime());
-    expect(dbDate.toISOString()).toBe(calendarDate.toISOString());
+    expect(dbDate.toISOString()).toBe('2026-07-01T15:15:00.123Z');
   });
 
-  it('normalizes date ranges for DB without introducing timezone drift', () => {
+  it('normalizes date ranges for DB as Vienna wall-clock timestamps', () => {
     const range = {
-      start: new Date(2026, 3, 23, 18, 15, 0, 0),
-      end: new Date(2026, 3, 23, 20, 15, 0, 0),
+      start: new Date('2026-07-01T13:15:00.000Z'),
+      end: new Date('2026-07-01T15:15:00.000Z'),
     };
 
     const normalized = normalizeDateRangeForDb(range);
 
-    expect(normalized.start.getTime()).toBe(range.start.getTime());
-    expect(normalized.end.getTime()).toBe(range.end.getTime());
+    expect(normalized.start.toISOString()).toBe('2026-07-01T15:15:00.000Z');
+    expect(normalized.end.toISOString()).toBe('2026-07-01T17:15:00.000Z');
   });
 });

--- a/src/features/einsatz/datetime.test.ts
+++ b/src/features/einsatz/datetime.test.ts
@@ -113,23 +113,24 @@ describe('datetime normalization', () => {
     expect(parsed?.getMinutes()).toBe(expectedMinute);
   });
 
-  it('converts calendar instants to Vienna wall-clock for DB writes', () => {
-    const calendarDate = new Date('2026-07-01T13:15:00.123Z');
+  it('preserves the original instant when converting calendar dates for DB writes', () => {
+    const calendarDate = new Date(2026, 3, 23, 18, 15, 0, 123);
 
     const dbDate = calendarDateToDbTimestamp(calendarDate);
 
-    expect(dbDate.toISOString()).toBe('2026-07-01T15:15:00.123Z');
+    expect(dbDate.getTime()).toBe(calendarDate.getTime());
+    expect(dbDate.toISOString()).toBe(calendarDate.toISOString());
   });
 
-  it('normalizes date ranges for DB as Vienna wall-clock timestamps', () => {
+  it('normalizes date ranges for DB without introducing timezone drift', () => {
     const range = {
-      start: new Date('2026-07-01T13:15:00.000Z'),
-      end: new Date('2026-07-01T15:15:00.000Z'),
+      start: new Date(2026, 3, 23, 18, 15, 0, 0),
+      end: new Date(2026, 3, 23, 20, 15, 0, 0),
     };
 
     const normalized = normalizeDateRangeForDb(range);
 
-    expect(normalized.start.toISOString()).toBe('2026-07-01T15:15:00.000Z');
-    expect(normalized.end.toISOString()).toBe('2026-07-01T17:15:00.000Z');
+    expect(normalized.start.getTime()).toBe(range.start.getTime());
+    expect(normalized.end.getTime()).toBe(range.end.getTime());
   });
 });

--- a/src/features/einsatz/datetime.ts
+++ b/src/features/einsatz/datetime.ts
@@ -13,19 +13,6 @@ type TimeDefaultRange = Pick<
   'default_starttime' | 'default_endtime'
 >;
 
-const ORGANIZATION_TIME_ZONE = 'Europe/Vienna';
-const VIENNA_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
-  timeZone: ORGANIZATION_TIME_ZONE,
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  fractionalSecondDigits: 3,
-  hour12: false,
-});
-
 /**
  * Realtime / wire timestamps are parsed by the runtime into local Date instances.
  * For calendar UX we keep those local wall-clock components unchanged.
@@ -91,27 +78,9 @@ export function prismaTimestampToCalendarDate(value: Date): Date {
 }
 
 export function calendarDateToDbTimestamp(value: Date): Date {
-  // Server Actions serialize Date values as instants.
-  // For "timestamp without time zone" columns we must persist wall-clock values
-  // in the org timezone independent of server timezone.
-  const parts = VIENNA_TIMESTAMP_FORMATTER.formatToParts(value);
-
-  const readPart = (type: Intl.DateTimeFormatPartTypes): number => {
-    const part = parts.find((entry) => entry.type === type);
-    return Number(part?.value ?? '0');
-  };
-
-  return new Date(
-    Date.UTC(
-      readPart('year'),
-      readPart('month') - 1,
-      readPart('day'),
-      readPart('hour'),
-      readPart('minute'),
-      readPart('second'),
-      readPart('fractionalSecond')
-    )
-  );
+  // Keep the original instant; converting local wall-clock parts via Date.UTC
+  // introduces a timezone shift (e.g. +/-2h) on every save.
+  return new Date(value.getTime());
 }
 
 export function normalizeDateRangeFromDb<T extends DateRange>(value: T): T {

--- a/src/features/einsatz/datetime.ts
+++ b/src/features/einsatz/datetime.ts
@@ -78,17 +78,9 @@ export function prismaTimestampToCalendarDate(value: Date): Date {
 }
 
 export function calendarDateToDbTimestamp(value: Date): Date {
-  return new Date(
-    Date.UTC(
-      value.getFullYear(),
-      value.getMonth(),
-      value.getDate(),
-      value.getHours(),
-      value.getMinutes(),
-      value.getSeconds(),
-      value.getMilliseconds()
-    )
-  );
+  // Keep the original instant; converting local wall-clock parts via Date.UTC
+  // introduces a timezone shift (e.g. +/-2h) on every save.
+  return new Date(value.getTime());
 }
 
 export function normalizeDateRangeFromDb<T extends DateRange>(value: T): T {

--- a/src/features/einsatz/datetime.ts
+++ b/src/features/einsatz/datetime.ts
@@ -13,6 +13,19 @@ type TimeDefaultRange = Pick<
   'default_starttime' | 'default_endtime'
 >;
 
+const ORGANIZATION_TIME_ZONE = 'Europe/Vienna';
+const VIENNA_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  timeZone: ORGANIZATION_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  fractionalSecondDigits: 3,
+  hour12: false,
+});
+
 /**
  * Realtime / wire timestamps are parsed by the runtime into local Date instances.
  * For calendar UX we keep those local wall-clock components unchanged.
@@ -78,9 +91,27 @@ export function prismaTimestampToCalendarDate(value: Date): Date {
 }
 
 export function calendarDateToDbTimestamp(value: Date): Date {
-  // Keep the original instant; converting local wall-clock parts via Date.UTC
-  // introduces a timezone shift (e.g. +/-2h) on every save.
-  return new Date(value.getTime());
+  // Server Actions serialize Date values as instants.
+  // For "timestamp without time zone" columns we must persist wall-clock values
+  // in the org timezone independent of server timezone.
+  const parts = VIENNA_TIMESTAMP_FORMATTER.formatToParts(value);
+
+  const readPart = (type: Intl.DateTimeFormatPartTypes): number => {
+    const part = parts.find((entry) => entry.type === type);
+    return Number(part?.value ?? '0');
+  };
+
+  return new Date(
+    Date.UTC(
+      readPart('year'),
+      readPart('month') - 1,
+      readPart('day'),
+      readPart('hour'),
+      readPart('minute'),
+      readPart('second'),
+      readPart('fractionalSecond')
+    )
+  );
 }
 
 export function normalizeDateRangeFromDb<T extends DateRange>(value: T): T {

--- a/src/features/einsatz/hooks/useEinsatzMutations.ts
+++ b/src/features/einsatz/hooks/useEinsatzMutations.ts
@@ -10,6 +10,7 @@ import {
 import { queryKeys } from '../queryKeys';
 import { activityLogQueryKeys } from '@/features/activity_log/queryKeys';
 import type { CalendarRangeData } from '@/components/event-calendar/utils';
+import { parseCalendarDateTimeString } from '@/features/einsatz/datetime';
 
 /** If isOverlap is true, returns the 3 monthKeys that overlap the 3-month window centered on the given date. Otherwise, returns the 1 monthKey for the given date. */
 export function getMonthKeysForDate(date: Date, isOverlap = true): string[] {
@@ -28,10 +29,23 @@ export function getMonthKeysForDate(date: Date, isOverlap = true): string[] {
 /** Object with start and optional end (Date or ISO string). Used for multi-day event invalidation. */
 type WithStartEnd = { start: Date | string; end?: Date | string };
 
+function toMutationDate(value: Date | string): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  const parsedWallClock = parseCalendarDateTimeString(value);
+  if (parsedWallClock) {
+    return parsedWallClock;
+  }
+
+  return new Date(value);
+}
+
 /** Returns one Date per calendar day from start through end (inclusive). If end is missing or before start, returns [startOfDay(start)]. */
 function getDatesSpanningEvent(event: WithStartEnd): Date[] {
-  const start = startOfDay(new Date(event.start));
-  const endRaw = event.end != null ? new Date(event.end) : start;
+  const start = startOfDay(toMutationDate(event.start));
+  const endRaw = event.end != null ? toMutationDate(event.end) : start;
   const end = startOfDay(endRaw);
   if (end < start) return [start];
   return eachDayOfInterval({ start, end });
@@ -228,9 +242,8 @@ export function useCreateEinsatz(
       const optimisticEvent: CalendarEvent = {
         id: `temp-${Date.now()}`,
         title: event.title,
-        start:
-          event.start instanceof Date ? event.start : new Date(event.start),
-        end: event.end instanceof Date ? event.end : new Date(event.end),
+        start: toMutationDate(event.start),
+        end: toMutationDate(event.end),
         allDay: event.all_day ?? false,
         assignedUsers: event.assignedUsers ?? [],
         helpersNeeded: event.helpers_needed,
@@ -348,9 +361,7 @@ export function useUpdateEinsatz(
       if (!eventId) return {};
       const start =
         'start' in event && event.start
-          ? event.start instanceof Date
-            ? event.start
-            : new Date(event.start)
+          ? toMutationDate(event.start)
           : null;
       const previousData: CalendarCacheSnapshot = [];
       const queries = queryClient.getQueriesData<CalendarRangeData>({
@@ -367,7 +378,7 @@ export function useUpdateEinsatz(
           ...(start && { start }),
           ...('end' in event &&
             event.end !== undefined && {
-              end: event.end instanceof Date ? event.end : new Date(event.end),
+              end: toMutationDate(event.end),
             }),
         };
         if ('title' in event && event.title !== undefined)

--- a/src/hooks/useSupabaseRealtime.test.ts
+++ b/src/hooks/useSupabaseRealtime.test.ts
@@ -97,10 +97,19 @@ describe('parseSupabaseRealtimeTimestamp', () => {
     expect(parsed?.getMilliseconds()).toBe(123);
   });
 
-  it('lässt Zeitstempel mit vorhandener Zeitzone unverändert durch den nativen Parser laufen', () => {
+  it('ignoriert ein Z-Suffix und behält die Wandzeit', () => {
     const parsed = parseSupabaseRealtimeTimestamp('2026-05-08T13:00:00.000Z');
 
     expect(parsed).toBeDefined();
-    expect(parsed?.toISOString()).toBe('2026-05-08T13:00:00.000Z');
+    expect(parsed?.getHours()).toBe(13);
+    expect(parsed?.getMinutes()).toBe(0);
+  });
+
+  it('ignoriert ein Offset-Suffix und behält die Wandzeit', () => {
+    const parsed = parseSupabaseRealtimeTimestamp('2026-05-08T13:00:00+02:00');
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.getHours()).toBe(13);
+    expect(parsed?.getMinutes()).toBe(0);
   });
 });

--- a/src/hooks/useSupabaseRealtime.test.ts
+++ b/src/hooks/useSupabaseRealtime.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { composeRealtimeEventTitle } from './useSupabaseRealtime.utils';
+import {
+  composeRealtimeEventTitle,
+  parseSupabaseRealtimeTimestamp,
+} from './useSupabaseRealtime.utils';
 
 describe('composeRealtimeEventTitle', () => {
   it('keeps the existing title when no new base title is provided', () => {
@@ -66,5 +69,30 @@ describe('composeRealtimeEventTitle', () => {
         nextBaseTitle: 'Neu',
       })
     ).toBe('Neu');
+  });
+});
+
+describe('parseSupabaseRealtimeTimestamp', () => {
+  it('interpretiert Zeitstempel ohne Zeitzone als UTC', () => {
+    const parsed = parseSupabaseRealtimeTimestamp('2026-05-08 13:00:00');
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.toISOString()).toBe('2026-05-08T13:00:00.000Z');
+  });
+
+  it('interpretiert Zeitstempel mit Mikrosekunden ohne Zeitzone als UTC', () => {
+    const parsed = parseSupabaseRealtimeTimestamp(
+      '2026-05-08 13:00:00.123456'
+    );
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.toISOString()).toBe('2026-05-08T13:00:00.123Z');
+  });
+
+  it('lässt Zeitstempel mit vorhandener Zeitzone unverändert durch den nativen Parser laufen', () => {
+    const parsed = parseSupabaseRealtimeTimestamp('2026-05-08T13:00:00.000Z');
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.toISOString()).toBe('2026-05-08T13:00:00.000Z');
   });
 });

--- a/src/hooks/useSupabaseRealtime.test.ts
+++ b/src/hooks/useSupabaseRealtime.test.ts
@@ -73,20 +73,28 @@ describe('composeRealtimeEventTitle', () => {
 });
 
 describe('parseSupabaseRealtimeTimestamp', () => {
-  it('interpretiert Zeitstempel ohne Zeitzone als UTC', () => {
+  it('interpretiert Zeitstempel ohne Zeitzone als lokale Wandzeit', () => {
     const parsed = parseSupabaseRealtimeTimestamp('2026-05-08 13:00:00');
 
     expect(parsed).toBeDefined();
-    expect(parsed?.toISOString()).toBe('2026-05-08T13:00:00.000Z');
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(4);
+    expect(parsed?.getDate()).toBe(8);
+    expect(parsed?.getHours()).toBe(13);
+    expect(parsed?.getMinutes()).toBe(0);
+    expect(parsed?.getSeconds()).toBe(0);
   });
 
-  it('interpretiert Zeitstempel mit Mikrosekunden ohne Zeitzone als UTC', () => {
+  it('interpretiert Zeitstempel mit Mikrosekunden ohne Zeitzone als lokale Wandzeit', () => {
     const parsed = parseSupabaseRealtimeTimestamp(
       '2026-05-08 13:00:00.123456'
     );
 
     expect(parsed).toBeDefined();
-    expect(parsed?.toISOString()).toBe('2026-05-08T13:00:00.123Z');
+    expect(parsed?.getHours()).toBe(13);
+    expect(parsed?.getMinutes()).toBe(0);
+    expect(parsed?.getSeconds()).toBe(0);
+    expect(parsed?.getMilliseconds()).toBe(123);
   });
 
   it('lässt Zeitstempel mit vorhandener Zeitzone unverändert durch den nativen Parser laufen', () => {

--- a/src/hooks/useSupabaseRealtime.ts
+++ b/src/hooks/useSupabaseRealtime.ts
@@ -577,6 +577,30 @@ function syncEinsatzRealtimeCaches(
     return;
   }
 
+  const hasTemporalUpdate =
+    payload.eventType === 'UPDATE' &&
+    (nextRecord?.start !== undefined || nextRecord?.end !== undefined);
+
+  if (hasTemporalUpdate) {
+    // Realtime payloads for timestamp columns can vary by environment
+    // (timezone suffix/no suffix). To avoid transient ±offset flicker, do not
+    // patch start/end from payload; fetch authoritative API-normalized values.
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.detailedEinsatz(einsatzId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.einsaetze(orgId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.einsaetzeForCalendarPrefix(orgId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.allLists(),
+      predicate: (query) => matchesEinsatzListQueryForOrg(query.queryKey, orgId),
+    });
+    return;
+  }
+
   const patch = buildEinsatzBasePatch(nextRecord ?? previousRecord ?? {});
 
   queryClient.setQueryData<EinsatzDetailed | null>(

--- a/src/hooks/useSupabaseRealtime.ts
+++ b/src/hooks/useSupabaseRealtime.ts
@@ -25,13 +25,16 @@ import type {
   EinsatzListItem,
 } from '@/features/einsatz/types';
 import type { CalendarEvent } from '@/components/event-calendar/types';
-import { parseCalendarDateTimeString } from '@/features/einsatz/datetime';
+import { dbTimestampToCalendarDate } from '@/features/einsatz/datetime';
 import type {
   RealtimeChannel,
   RealtimePostgresChangesPayload,
 } from '@supabase/supabase-js';
 import type { einsatz as Einsatz } from '@/generated/prisma';
-import { composeRealtimeEventTitle } from './useSupabaseRealtime.utils';
+import {
+  composeRealtimeEventTitle,
+  parseSupabaseRealtimeTimestamp,
+} from './useSupabaseRealtime.utils';
 
 type EinsatzRow = {
   id: string;
@@ -107,7 +110,8 @@ function toInstantDate(value: string | null | undefined): Date | undefined {
 }
 
 function toCalendarDate(value: string | null | undefined): Date | undefined {
-  return parseCalendarDateTimeString(value);
+  const parsed = parseSupabaseRealtimeTimestamp(value);
+  return parsed ? dbTimestampToCalendarDate(parsed) : undefined;
 }
 
 function isEinsatzRow(value: unknown): value is EinsatzRow {

--- a/src/hooks/useSupabaseRealtime.ts
+++ b/src/hooks/useSupabaseRealtime.ts
@@ -577,14 +577,11 @@ function syncEinsatzRealtimeCaches(
     return;
   }
 
-  const hasTemporalUpdate =
-    payload.eventType === 'UPDATE' &&
-    (nextRecord?.start !== undefined || nextRecord?.end !== undefined);
-
-  if (hasTemporalUpdate) {
-    // Realtime payloads for timestamp columns can vary by environment
-    // (timezone suffix/no suffix). To avoid transient ±offset flicker, do not
-    // patch start/end from payload; fetch authoritative API-normalized values.
+  if (payload.eventType === 'UPDATE') {
+    // Never patch einsatz UPDATE payloads directly into caches.
+    // UPDATE payload timestamp serialization can differ by environment
+    // and has caused transient timezone flicker in deployment.
+    // Always refetch authoritative, API-normalized data instead.
     queryClient.invalidateQueries({
       queryKey: queryKeys.detailedEinsatz(einsatzId),
     });

--- a/src/hooks/useSupabaseRealtime.utils.ts
+++ b/src/hooks/useSupabaseRealtime.utils.ts
@@ -50,16 +50,17 @@ export function parseSupabaseRealtimeTimestamp(
     return undefined;
   }
 
-  // `timestamp without time zone` must be interpreted as local wall-clock time.
-  // Do not coerce to UTC by appending "Z".
-  const timestampWithoutTimezoneMatch =
-    /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?$/.exec(
+  // `timestamp without time zone` should always be interpreted as wall-clock time.
+  // Some realtime payloads may still include a zone suffix (`Z` / `+02:00`);
+  // we intentionally ignore that suffix to avoid ±offset drift in the UI.
+  const timestampMatch =
+    /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(?:Z|[+\-]\d{2}:?\d{2})?$/.exec(
       value
     );
 
-  if (timestampWithoutTimezoneMatch) {
+  if (timestampMatch) {
     const [, year, month, day, hours, minutes, seconds, milliseconds] =
-      timestampWithoutTimezoneMatch;
+      timestampMatch;
     const normalizedMilliseconds = (milliseconds ?? '0')
       .slice(0, 3)
       .padEnd(3, '0');

--- a/src/hooks/useSupabaseRealtime.utils.ts
+++ b/src/hooks/useSupabaseRealtime.utils.ts
@@ -42,3 +42,32 @@ export function composeRealtimeEventTitle(params: {
 
   return nextBaseTitle;
 }
+
+export function parseSupabaseRealtimeTimestamp(
+  value: string | null | undefined
+): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  // Supabase can deliver `timestamp without time zone` values without zone info.
+  // In our pipeline those values represent UTC instants, so we normalize to ISO-Z.
+  const timestampWithoutTimezoneMatch =
+    /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?$/.exec(
+      value
+    );
+
+  if (timestampWithoutTimezoneMatch) {
+    const [, year, month, day, hours, minutes, seconds, milliseconds] =
+      timestampWithoutTimezoneMatch;
+    const normalizedMilliseconds = (milliseconds ?? '0')
+      .slice(0, 3)
+      .padEnd(3, '0');
+    const isoWithUtcZone = `${year}-${month}-${day}T${hours}:${minutes}:${seconds ?? '00'}.${normalizedMilliseconds}Z`;
+    const parsedUtcDate = new Date(isoWithUtcZone);
+    return Number.isNaN(parsedUtcDate.getTime()) ? undefined : parsedUtcDate;
+  }
+
+  const parsedDate = new Date(value);
+  return Number.isNaN(parsedDate.getTime()) ? undefined : parsedDate;
+}

--- a/src/hooks/useSupabaseRealtime.utils.ts
+++ b/src/hooks/useSupabaseRealtime.utils.ts
@@ -50,8 +50,8 @@ export function parseSupabaseRealtimeTimestamp(
     return undefined;
   }
 
-  // Supabase can deliver `timestamp without time zone` values without zone info.
-  // In our pipeline those values represent UTC instants, so we normalize to ISO-Z.
+  // `timestamp without time zone` must be interpreted as local wall-clock time.
+  // Do not coerce to UTC by appending "Z".
   const timestampWithoutTimezoneMatch =
     /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?$/.exec(
       value
@@ -63,9 +63,16 @@ export function parseSupabaseRealtimeTimestamp(
     const normalizedMilliseconds = (milliseconds ?? '0')
       .slice(0, 3)
       .padEnd(3, '0');
-    const isoWithUtcZone = `${year}-${month}-${day}T${hours}:${minutes}:${seconds ?? '00'}.${normalizedMilliseconds}Z`;
-    const parsedUtcDate = new Date(isoWithUtcZone);
-    return Number.isNaN(parsedUtcDate.getTime()) ? undefined : parsedUtcDate;
+
+    return new Date(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hours),
+      Number(minutes),
+      Number(seconds ?? 0),
+      Number(normalizedMilliseconds)
+    );
   }
 
   const parsedDate = new Date(value);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calendar-to-database timestamp handling so displayed times match the intended local wall-clock zone (prevents 2‑hour drift).

* **New Features**
  * Improved realtime timestamp parsing and cache sync logic to ensure reliable live updates and consistent displayed times.

* **Tests**
  * Added tests validating datetime conversions and realtime timestamp parsing to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->