### PR TITLE
feat: add configurable calendar exports

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,6 +169,7 @@ model organization {
   trial_ends_at                             DateTime?                                   @db.Timestamptz(6)
   subscription_status                       String                                      @default("trial")
   analytics_chart                           analytics_chart[]
+  calendar_export_template                  calendar_export_template[]
   calendar_subscription                     calendar_subscription[]
   einsatz                                   einsatz[]
   einsatz_category                          einsatz_category[]
@@ -391,10 +392,12 @@ model calendar_subscription {
   is_active     Boolean      @default(true)
   created_at    DateTime     @default(now()) @db.Timestamptz(6)
   last_accessed DateTime?    @db.Timestamptz(6)
+  config        Json?
   organization  organization @relation(fields: [org_id], references: [id], onDelete: Cascade)
   user          user         @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@index([org_id, user_id, is_active])
+  @@index([user_id, org_id, is_active, name], map: "calendar_subscription_user_org_active_name_idx")
 }
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
@@ -619,4 +622,18 @@ model otp_code {
   consumed_at      DateTime?     @db.Timestamptz(6)
   otp_challenge_id String        @db.Uuid
   otp_challenge    otp_challenge @relation(fields: [otp_challenge_id], references: [id], onDelete: Cascade)
+}
+
+model calendar_export_template {
+  id           String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  org_id       String       @db.Uuid
+  name         String
+  description  String?
+  config       Json
+  created_at   DateTime     @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime?    @db.Timestamptz(6)
+  organization organization @relation(fields: [org_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([org_id])
+  @@index([org_id, name], map: "calendar_export_template_org_name_idx")
 }

--- a/src/app/(pages)/(main)/settings/org/[orgId]/page.tsx
+++ b/src/app/(pages)/(main)/settings/org/[orgId]/page.tsx
@@ -1112,7 +1112,7 @@ export default function OrganizationManagePage() {
           <TemplatesOverviewSection orgId={orgId} />
         </section>
 
-        {/* User Properties Section */}
+        {/* Calendar Export Templates Section */}
         <section
           id="calendar-export-templates"
           ref={(el) => {

--- a/src/app/(pages)/(main)/settings/org/[orgId]/page.tsx
+++ b/src/app/(pages)/(main)/settings/org/[orgId]/page.tsx
@@ -31,6 +31,7 @@ import { UsersManagementSection } from '@/components/settings/org/UserManagement
 import { UserProperties } from '@/features/user_properties/components/UserProperties';
 import { TemplatesOverviewSection } from '@/components/template/TemplatesOverviewSection';
 import { OrganizationPdfExportForm } from '@/components/settings/org/OrganizationPdfExportForm';
+import { OrganizationCalendarExportTemplates } from '@/components/settings/org/OrganizationCalendarExportTemplates';
 import { PageHeader } from '@/components/settings/PageHeader';
 import {
   ORG_MANAGE_NAV_ITEMS,
@@ -127,14 +128,18 @@ export default function OrganizationManagePage() {
     notificationMinimumPriorityDefault,
     setNotificationMinimumPriorityDefault,
   ] = useState<'info' | 'review' | 'critical'>('review');
-  const [notificationUrgentDeliveryDefault, setNotificationUrgentDeliveryDefault] =
-    useState<'immediate' | 'digest'>('immediate');
+  const [
+    notificationUrgentDeliveryDefault,
+    setNotificationUrgentDeliveryDefault,
+  ] = useState<'immediate' | 'digest'>('immediate');
   const [
     notificationImportantDeliveryDefault,
     setNotificationImportantDeliveryDefault,
   ] = useState<'immediate' | 'digest'>('digest');
-  const [notificationGeneralDeliveryDefault, setNotificationGeneralDeliveryDefault] =
-    useState<'digest' | 'off'>('off');
+  const [
+    notificationGeneralDeliveryDefault,
+    setNotificationGeneralDeliveryDefault,
+  ] = useState<'digest' | 'off'>('off');
   const [
     notificationDigestIntervalDefault,
     setNotificationDigestIntervalDefault,
@@ -372,11 +377,15 @@ export default function OrganizationManagePage() {
     setNotificationMinimumPriorityDefault(
       notificationDefaults.minimumPriorityDefault
     );
-    setNotificationUrgentDeliveryDefault(notificationDefaults.urgentDeliveryDefault);
+    setNotificationUrgentDeliveryDefault(
+      notificationDefaults.urgentDeliveryDefault
+    );
     setNotificationImportantDeliveryDefault(
       notificationDefaults.importantDeliveryDefault
     );
-    setNotificationGeneralDeliveryDefault(notificationDefaults.generalDeliveryDefault);
+    setNotificationGeneralDeliveryDefault(
+      notificationDefaults.generalDeliveryDefault
+    );
     setNotificationDigestIntervalDefault(
       notificationDefaults.digestIntervalDefault
     );
@@ -1013,9 +1022,7 @@ export default function OrganizationManagePage() {
                 deliveryModeDefault={notificationDeliveryModeDefault}
                 minimumPriorityDefault={notificationMinimumPriorityDefault}
                 urgentDeliveryDefault={notificationUrgentDeliveryDefault}
-                importantDeliveryDefault={
-                  notificationImportantDeliveryDefault
-                }
+                importantDeliveryDefault={notificationImportantDeliveryDefault}
                 generalDeliveryDefault={notificationGeneralDeliveryDefault}
                 digestIntervalDefault={notificationDigestIntervalDefault}
                 digestTimeDefault={notificationDigestTimeDefault}
@@ -1103,6 +1110,41 @@ export default function OrganizationManagePage() {
             Vorlagen
           </h2>
           <TemplatesOverviewSection orgId={orgId} />
+        </section>
+
+        {/* User Properties Section */}
+        <section
+          id="calendar-export-templates"
+          ref={(el) => {
+            sectionRefs.current['calendar-export-templates'] = el;
+          }}
+          aria-labelledby="calendar-export-templates-heading"
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle id="calendar-export-templates-heading">
+                Kalenderexport-Vorlagen
+              </CardTitle>
+              <CardDescription>
+                Vorgeschlagene Kalenderexporte für persönliche
+                Kalenderabonnements verwalten.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {orgData ? (
+                <OrganizationCalendarExportTemplates
+                  org={{
+                    id: orgData.id,
+                    name: orgData.name,
+                    helper_name_singular: orgData.helper_name_singular,
+                    helper_name_plural: orgData.helper_name_plural,
+                    einsatz_name_singular: orgData.einsatz_name_singular,
+                    einsatz_name_plural: orgData.einsatz_name_plural,
+                  }}
+                />
+              ) : null}
+            </CardContent>
+          </Card>
         </section>
 
         {/* User Properties Section */}

--- a/src/app/(pages)/(main)/settings/user/page.tsx
+++ b/src/app/(pages)/(main)/settings/user/page.tsx
@@ -45,7 +45,6 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
-  CalendarExportGlobalCreate,
   CalendarIntegrationCard,
   NAV_ITEMS,
   type SectionId,

--- a/src/app/(pages)/(main)/settings/user/page.tsx
+++ b/src/app/(pages)/(main)/settings/user/page.tsx
@@ -45,6 +45,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
+  CalendarExportGlobalCreate,
   CalendarIntegrationCard,
   NAV_ITEMS,
   type SectionId,
@@ -618,46 +619,50 @@ export default function SettingsPage() {
         >
           <Card>
             <CardHeader>
-              <CardTitle id="calendar-heading">
-                Kalender-Integrationen
-              </CardTitle>
-              <CardDescription>
-                Abonnieren Sie Kalender Ihrer Organisationen in externen Apps
-                wie Google Calendar, Apple Calendar oder Outlook
-              </CardDescription>
+              <div className="flex flex-col flex-wrap items-start justify-between gap-3">
+                <div>
+                  <CardTitle id="calendar-heading">Kalenderexporte</CardTitle>
+                  <CardDescription>
+                    Abonnieren Sie Kalender Ihrer Organisationen in externen
+                    Apps wie Google Calendar, Apple Calendar oder Outlook
+                  </CardDescription>
+                </div>
+                <div className="bg-muted/50 rounded-lg p-4">
+                  <h4 className="mb-2 text-sm font-medium">
+                    So funktioniert&apos;s
+                  </h4>
+                  <ol className="text-muted-foreground space-y-2 text-sm">
+                    <li className="flex gap-2">
+                      <span className="bg-primary/10 text-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                        1
+                      </span>
+                      Kopieren Sie die URL oder klicken Sie auf &quot;In
+                      Kalender öffnen&quot;
+                    </li>
+                    <li className="flex gap-2">
+                      <span className="bg-primary/10 text-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                        2
+                      </span>
+                      Fügen Sie die URL in Ihrer Kalender-App als Abonnement
+                      hinzu
+                    </li>
+                    <li className="flex gap-2">
+                      <span className="bg-primary/10 text-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+                        3
+                      </span>
+                      Ihr Kalender synchronisiert automatisch alle Ereignisse
+                    </li>
+                  </ol>
+                </div>
+                {/* <CalendarExportGlobalCreate
+                  activeOrgId={session?.user?.activeOrganization?.id}
+                /> */}
+              </div>
             </CardHeader>
             <CardContent>
               {organizations.length > 0 ? (
                 <div className="space-y-4">
-                  <div className="bg-muted/50 rounded-lg p-4">
-                    <h4 className="mb-2 text-sm font-medium">
-                      So funktioniert&apos;s
-                    </h4>
-                    <ol className="text-muted-foreground space-y-2 text-sm">
-                      <li className="flex gap-2">
-                        <span className="bg-primary/10 text-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                          1
-                        </span>
-                        Kopieren Sie die URL oder klicken Sie auf &quot;In
-                        Kalender öffnen&quot;
-                      </li>
-                      <li className="flex gap-2">
-                        <span className="bg-primary/10 text-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                          2
-                        </span>
-                        Fügen Sie die URL in Ihrer Kalender-App als Abonnement
-                        hinzu
-                      </li>
-                      <li className="flex gap-2">
-                        <span className="bg-primary/10 text-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                          3
-                        </span>
-                        Ihr Kalender synchronisiert automatisch alle Ereignisse
-                      </li>
-                    </ol>
-                  </div>
-
-                  <Separator className="my-6" />
+                  <Separator className="mb-6" />
 
                   {organizations.map((org) => (
                     <CalendarIntegrationCard key={org.id} org={org} />
@@ -704,25 +709,24 @@ export default function SettingsPage() {
                     return (
                       <div
                         key={org.id}
-                        className="flex flex-col gap-4 rounded-lg border p-4 pl-2 sm:flex-row sm:items-center sm:justify-between"
+                        className="flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
                       >
-                        <div className="flex items-center">
-                          <div className="flex w-20 justify-center">
+                        <div className="flex items-center gap-3">
+                          <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg">
                             {logoUrl ? (
                               <Image
                                 src={logoUrl}
                                 alt={org.name}
-                                width={80}
-                                height={60}
+                                width={40}
+                                height={40}
+                                className="h-full w-full object-contain p-1.5"
                               />
                             ) : (
-                              <div className="bg-muted flex size-10 items-center justify-center rounded-full p-2">
-                                <Building2 className="size-4" />
-                              </div>
+                              <Building2 className="text-muted-foreground h-5 w-5" />
                             )}
                           </div>
                           <div className="space-y-2">
-                            <h3 className="text-lg font-semibold">
+                            <h3 className="leading-none font-medium">
                               {org.name}
                             </h3>
                             <RolesList

--- a/src/app/api/calendar/[token]/route.test.ts
+++ b/src/app/api/calendar/[token]/route.test.ts
@@ -6,11 +6,13 @@ const {
   mockFindSubscription,
   mockFindEinsaetze,
   mockUpdateSubscription,
+  mockFindUserOrgRoles,
 } = vi.hoisted(() => ({
   mockCreateEvent: vi.fn(),
   mockFindSubscription: vi.fn(),
   mockFindEinsaetze: vi.fn(),
   mockUpdateSubscription: vi.fn(),
+  mockFindUserOrgRoles: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -21,6 +23,9 @@ vi.mock('@/lib/prisma', () => ({
     },
     einsatz: {
       findMany: mockFindEinsaetze,
+    },
+    user_organization_role: {
+      findMany: mockFindUserOrgRoles,
     },
   },
 }));
@@ -49,10 +54,27 @@ describe('GET /api/calendar/[token]', () => {
     mockFindSubscription.mockReset();
     mockFindEinsaetze.mockReset();
     mockUpdateSubscription.mockReset();
+    mockFindUserOrgRoles.mockReset();
 
     mockFindSubscription.mockResolvedValue({
+      user_id: 'user-1',
       org_id: 'orga-1',
+      name: 'Mein Export',
       is_active: true,
+      config: {
+        version: 1,
+        mode: 'helper',
+        categoryIds: [],
+        statusIds: [],
+        statusPseudo: [],
+        timeWindow: null,
+        includeAllDay: true,
+        futureOnly: false,
+        titleAdditions: {
+          categories: true,
+          helperCount: true,
+        },
+      },
       organization: {
         name: 'Organisation',
         email: null,
@@ -75,13 +97,17 @@ describe('GET /api/calendar/[token]', () => {
         total_price: null,
         einsatz_to_category: [
           {
+            category_id: 'cat-1',
             einsatz_category: {
+              id: 'cat-1',
               value: 'Dauerausstellung',
               abbreviation: 'DA',
             },
           },
           {
+            category_id: 'cat-2',
             einsatz_category: {
+              id: 'cat-2',
               value: 'Veranstaltung',
               abbreviation: 'VA',
             },
@@ -91,15 +117,29 @@ describe('GET /api/calendar/[token]', () => {
         einsatz_user_property: [],
         einsatz_helper: [
           {
+            user_id: 'user-1',
             user: {
+              id: 'user-1',
               firstname: 'Erika',
               lastname: 'Musterfrau',
             },
           },
         ],
-        einsatz_status: null,
+        status_id: 'status-1',
+        einsatz_status: {
+          id: 'status-1',
+          helper_text: 'vergeben',
+          verwalter_text: 'vergeben',
+        },
         organization: {
           name: 'Organisation',
+        },
+      },
+    ]);
+    mockFindUserOrgRoles.mockResolvedValue([
+      {
+        role: {
+          name: 'Helfer',
         },
       },
     ]);
@@ -113,7 +153,7 @@ describe('GET /api/calendar/[token]', () => {
     process.env.NEXTAUTH_URL = previousNextAuthUrl;
   });
 
-  it('verwendet den In-App-Kalendertitel als Summary', async () => {
+  it('verwendet den Kalenderexport-Titel als Summary', async () => {
     await GET(
       new NextRequest('https://einsatzplaner.example/api/calendar/token'),
       {
@@ -123,7 +163,7 @@ describe('GET /api/calendar/[token]', () => {
 
     expect(mockCreateEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        summary: 'Führung (DA, VA)(1/2)',
+        summary: 'Führung (DA, VA · 1/2)',
       })
     );
   });

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -1,11 +1,64 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import ical, { ICalEventStatus, ICalCalendarMethod } from 'ical-generator';
-import { composeCalendarEventTitle } from '@/components/event-calendar/event-title';
+import { ROLE_PERMISSION_MAP } from '@/lib/auth/authGuard';
+import { parseCalendarExportConfig } from '@/features/calendar-subscription/config';
+import { filterCalendarExportEvents } from '@/features/calendar-subscription/filter';
+import {
+  composeCalendarExportEventTitle,
+  slugifyCalendarExportFilenamePart,
+} from '@/features/calendar-subscription/title';
 
 type RouteContext = {
   params: Promise<{ token: string }>;
 };
+
+function roleHasPermission(roleName: string, permission: string) {
+  return (ROLE_PERMISSION_MAP[roleName] ?? []).includes(permission);
+}
+
+async function subscriptionOwnerHasAccess(input: {
+  userId: string;
+  orgId: string;
+  requiresManagementMode: boolean;
+}) {
+  const roles = await prisma.user_organization_role.findMany({
+    where: {
+      user_id: input.userId,
+      org_id: input.orgId,
+    },
+    include: {
+      role: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  });
+
+  const roleNames = roles
+    .map((role) => role.role?.name)
+    .filter((roleName): roleName is string => Boolean(roleName));
+
+  const hasReadAccess = roleNames.some((roleName) =>
+    roleHasPermission(roleName, 'einsaetze:read')
+  );
+
+  if (!hasReadAccess) {
+    return false;
+  }
+
+  if (!input.requiresManagementMode) {
+    return true;
+  }
+
+  return roleNames.some(
+    (roleName) =>
+      roleHasPermission(roleName, 'einsaetze:create') ||
+      roleHasPermission(roleName, 'einsaetze:update') ||
+      roleHasPermission(roleName, 'einsaetze:delete')
+  );
+}
 
 export async function GET(request: NextRequest, context: RouteContext) {
   const prms = await context.params;
@@ -32,13 +85,24 @@ export async function GET(request: NextRequest, context: RouteContext) {
   if (!subscription || !subscription.is_active)
     return new NextResponse('Not found', { status: 404 });
 
+  const exportConfig = parseCalendarExportConfig(subscription.config);
+  const ownerHasAccess = await subscriptionOwnerHasAccess({
+    userId: subscription.user_id,
+    orgId: subscription.org_id,
+    requiresManagementMode: exportConfig.mode === 'verwaltung',
+  });
+
+  if (!ownerHasAccess) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
   // Organisationsspezifische Bezeichnungen
   const helperNamePlural =
     subscription.organization.helper_name_plural ?? 'Vermittler:innen';
   const einsatzNameSingular =
     subscription.organization.einsatz_name_singular ?? 'Einsatz';
 
-  const einsaetze = await prisma.einsatz.findMany({
+  const allEinsaetze = await prisma.einsatz.findMany({
     where: { org_id: subscription.org_id },
     orderBy: { start: 'asc' },
     include: {
@@ -54,6 +118,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         include: {
           einsatz_category: {
             select: {
+              id: true,
               value: true,
               abbreviation: true,
             },
@@ -93,6 +158,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         include: {
           user: {
             select: {
+              id: true,
               firstname: true,
               lastname: true,
             },
@@ -102,11 +168,18 @@ export async function GET(request: NextRequest, context: RouteContext) {
       einsatz_status: {
         select: {
           verwalter_text: true,
+          helper_text: true,
           id: true,
         },
       },
     },
   });
+
+  const { events: einsaetze, trimmedBefore } = filterCalendarExportEvents(
+    allEinsaetze,
+    exportConfig,
+    subscription.user_id
+  );
 
   const baseUrl = process.env.NEXTAUTH_URL;
   let host: string;
@@ -120,7 +193,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
   }
 
   const calendar = ical({
-    name: subscription.organization.name ?? 'Einsatzplaner - Kalender',
+    name: `${subscription.name ?? 'Kalenderexport'} - ${
+      subscription.organization.name ?? 'Einsatzplaner'
+    }`,
     method: ICalCalendarMethod.PUBLISH,
     ttl: 60 * 60 * 2,
     prodId: {
@@ -171,7 +246,22 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     // Status
     if (einsatz.einsatz_status?.verwalter_text) {
-      descriptionParts.push(`Status: ${einsatz.einsatz_status.verwalter_text}`);
+      descriptionParts.push(
+        `Status: ${
+          exportConfig.mode === 'helper'
+            ? einsatz.einsatz_status.helper_text
+            : einsatz.einsatz_status.verwalter_text
+        }`
+      );
+      descriptionParts.push('');
+    }
+
+    if (trimmedBefore) {
+      descriptionParts.push(
+        `Hinweis: Ereignisse vor dem ${trimmedBefore.toLocaleDateString(
+          'de-AT'
+        )} werden zur besseren Synchronisation nicht exportiert.`
+      );
       descriptionParts.push('');
     }
 
@@ -286,13 +376,13 @@ export async function GET(request: NextRequest, context: RouteContext) {
       start,
       end,
       allDay: isAllDay,
-      summary: composeCalendarEventTitle(
-        einsatz.title,
+      summary: composeCalendarExportEventTitle({
+        title: einsatz.title,
         categoryAbbreviations,
-        einsatz.helpers_needed > 0
-          ? `${einsatz.einsatz_helper.length}/${einsatz.helpers_needed}`
-          : []
-      ),
+        assignedHelpers: einsatz.einsatz_helper.length,
+        helpersNeeded: einsatz.helpers_needed,
+        config: exportConfig,
+      }),
       description,
       categories: categories.map((name) => ({ name })),
       location: ortField?.value ?? undefined,
@@ -317,11 +407,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
     status: 200,
     headers: {
       'Content-Type': 'text/calendar; charset=utf-8',
-      'Content-Disposition': `inline; filename="${(
+      'Content-Disposition': `inline; filename="${slugifyCalendarExportFilenamePart(
         subscription.organization.name ?? 'einsatzplaner'
-      )
-        .replace(/\s+/g, '-')
-        .toLowerCase()}.ics"`,
+      )}-${slugifyCalendarExportFilenamePart(
+        subscription.name ?? 'kalenderexport'
+      )}.ics"`,
       'Cache-Control': 'public, max-age=300',
     },
   });

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -245,14 +245,13 @@ export async function GET(request: NextRequest, context: RouteContext) {
     }
 
     // Status
-    if (einsatz.einsatz_status?.verwalter_text) {
-      descriptionParts.push(
-        `Status: ${
-          exportConfig.mode === 'helper'
-            ? einsatz.einsatz_status.helper_text
-            : einsatz.einsatz_status.verwalter_text
-        }`
-      );
+    const statusText =
+      exportConfig.mode === 'helper'
+        ? einsatz.einsatz_status?.helper_text
+        : einsatz.einsatz_status?.verwalter_text;
+
+    if (statusText) {
+      descriptionParts.push(`Status: ${statusText}`);
       descriptionParts.push('');
     }
 

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -3,6 +3,7 @@ export {
   CalendarIntegrationCard,
   type CalendarIntegrationCardProps,
 } from './userProfile/CalendarIntegrationCard';
+export { CalendarExportGlobalCreate } from './userProfile/CalendarExportGlobalCreate';
 export { NAV_ITEMS, type SectionId } from './constants';
 export { PageHeader } from './PageHeader';
 export {

--- a/src/components/settings/org-manage-constants.ts
+++ b/src/components/settings/org-manage-constants.ts
@@ -7,6 +7,7 @@ import {
   LayoutTemplate,
   SlidersHorizontal,
   Bell,
+  CalendarCog,
 } from 'lucide-react';
 
 // Navigation items for the organization manage sidebar - (icons currently not used)
@@ -16,6 +17,11 @@ export const ORG_MANAGE_NAV_ITEMS = [
   { id: 'notifications', label: 'Benachrichtigungen', icon: Bell },
   { id: 'standardfelder', label: 'Standardfelder', icon: SlidersHorizontal },
   { id: 'vorlagen', label: 'Vorlagen & eigene Felder', icon: LayoutTemplate },
+  {
+    id: 'calendar-export-templates',
+    label: 'Kalenderexport-Vorlagen',
+    icon: CalendarCog,
+  },
   { id: 'user-properties', label: 'Personeneigenschaften', icon: FileText },
   { id: 'users', label: 'Benutzer', icon: Users },
   { id: 'pdf-export', label: 'PDF-Export', icon: FileDown },

--- a/src/components/settings/org/OrganizationCalendarExportTemplates.tsx
+++ b/src/components/settings/org/OrganizationCalendarExportTemplates.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import {
+  useCalendarExportTemplates,
+  type CalendarExportTemplate,
+} from '@/features/calendar-subscription/hooks/useCalendarSubscription';
+import { CalendarExportDialog } from '@/components/settings/userProfile/CalendarExportDialog';
+
+type OrganizationCalendarExportTemplatesProps = {
+  org: {
+    id: string;
+    name: string;
+    helper_name_singular?: string | null;
+    helper_name_plural?: string | null;
+    einsatz_name_singular?: string | null;
+    einsatz_name_plural?: string | null;
+  };
+};
+
+function modeLabel(mode: string) {
+  return mode === 'verwaltung' ? 'Verwaltung' : 'Helfer';
+}
+
+export function OrganizationCalendarExportTemplates({
+  org,
+}: OrganizationCalendarExportTemplatesProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTemplate, setEditTemplate] =
+    useState<CalendarExportTemplate | null>(null);
+  const templates = useCalendarExportTemplates(org.id);
+  const { showDestructive } = useConfirmDialog();
+
+  const eligibility = [
+    {
+      organization: {
+        id: org.id,
+        name: org.name,
+        helper_name_singular: org.helper_name_singular ?? 'Helfer:in',
+        helper_name_plural: org.helper_name_plural ?? 'Helfer:innen',
+        einsatz_name_singular: org.einsatz_name_singular ?? 'Einsatz',
+        einsatz_name_plural: org.einsatz_name_plural ?? 'Einsätze',
+      },
+      modes: ['helper', 'verwaltung'] as const,
+    },
+  ];
+
+  const sortedTemplates = [...(templates.query.data ?? [])].sort(
+    (left, right) => {
+      if (left.config.mode !== right.config.mode) {
+        return left.config.mode === 'helper' ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name, 'de-AT');
+    }
+  );
+
+  const openCreateDialog = () => {
+    setEditTemplate(null);
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (template: CalendarExportTemplate) => {
+    setEditTemplate(template);
+    setDialogOpen(true);
+  };
+
+  const deleteTemplate = async (template: CalendarExportTemplate) => {
+    const result = await showDestructive(
+      'Kalenderexport-Vorlage löschen?',
+      `Möchten Sie die Vorlage „${template.name}“ wirklich löschen? Bestehende persönliche Kalenderexporte bleiben unverändert.`,
+      { confirmText: 'Löschen', cancelText: 'Abbrechen' }
+    );
+
+    if (result !== 'success') {
+      return;
+    }
+
+    templates.removeTemplate.mutate({ orgId: org.id, id: template.id });
+  };
+
+  if (templates.query.isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap justify-between gap-3">
+        <div>
+          <p className="text-muted-foreground text-sm">
+            Diese Vorlagen werden Benutzern beim Erstellen persönlicher
+            Kalenderexporte vorgeschlagen.
+          </p>
+        </div>
+        <Button onClick={openCreateDialog}>
+          <Plus className="mr-2 h-4 w-4" />
+          Vorlage erstellen
+        </Button>
+      </div>
+
+      {sortedTemplates.length === 0 ? (
+        <div className="rounded-md border border-dashed p-6 text-center">
+          <p className="font-medium">Keine Kalenderexport-Vorlagen</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Erstellen Sie eine Vorlage, damit Benutzer schneller passende
+            Kalenderexporte anlegen können.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {sortedTemplates.map((template) => (
+            <div
+              key={template.id}
+              className="flex items-center justify-between gap-3 rounded-md border p-3"
+            >
+              <div>
+                <div className="flex items-center gap-2">
+                  <p className="font-medium">{template.name}</p>
+                  <span className="text-muted-foreground rounded-full border px-2 py-0.5 text-xs">
+                    {modeLabel(template.config.mode)}
+                  </span>
+                </div>
+                {template.description ? (
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    {template.description}
+                  </p>
+                ) : null}
+                <p className="text-muted-foreground mt-1 text-xs">
+                  {template.config.mode === 'verwaltung'
+                    ? 'Nur für Personen mit Verwaltungszugriff nutzbar.'
+                    : 'Für Personen mit Helferzugriff nutzbar.'}
+                </p>
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon">
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => openEditDialog(template)}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Bearbeiten
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="text-destructive"
+                    onClick={() => deleteTemplate(template)}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Löschen
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <CalendarExportDialog
+        open={dialogOpen}
+        mode="template"
+        eligibility={eligibility}
+        initialOrgId={org.id}
+        templateToEdit={editTemplate}
+        onOpenChange={setDialogOpen}
+        onSaveTemplate={async (input) => {
+          if (input.id) {
+            await templates.updateTemplate.mutateAsync({
+              id: input.id,
+              orgId: org.id,
+              name: input.name,
+              description: input.description,
+              config: input.config,
+            });
+            return;
+          }
+
+          await templates.createTemplate.mutateAsync({
+            orgId: org.id,
+            name: input.name,
+            description: input.description,
+            config: input.config,
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -1,0 +1,859 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Copy, ExternalLink } from 'lucide-react';
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+import { MultiSelect } from '@/components/form/multi-select';
+import { TimeTextInput } from '@/components/form/TimeTextInput';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useCategories } from '@/features/einsatz/hooks/useEinsatzQueries';
+import { useStatuses } from '@/features/einsatz_status/hooks/useStatuses';
+import {
+  calendarExportConfigSchema,
+  getBlankCalendarExportConfig,
+  type CalendarExportConfig,
+  type CalendarExportMode,
+} from '@/features/calendar-subscription/config';
+import {
+  useCalendarExportPreview,
+  useCompatibleCalendarExportTemplates,
+  type CalendarExport,
+  type CalendarExportEligibility,
+} from '@/features/calendar-subscription/hooks/useCalendarSubscription';
+import { cn } from '@/lib/utils';
+
+const formSchema = z.object({
+  orgId: z.string().uuid(),
+  name: z.string().trim().min(1, 'Der Name ist erforderlich.'),
+  description: z.string().optional(),
+  config: calendarExportConfigSchema,
+});
+
+type FormValues = z.infer<typeof formSchema>;
+type SavedExport = {
+  name: string;
+  webcalUrl: string;
+  httpUrl: string;
+};
+
+type CalendarExportTemplateChoice = {
+  id: string;
+  orgId: string;
+  name: string;
+  description: string | null;
+  config: CalendarExportConfig;
+};
+
+type CalendarExportDialogProps = {
+  open: boolean;
+  mode: 'personal' | 'template';
+  eligibility: CalendarExportEligibility[];
+  initialOrgId?: string | null;
+  exportToEdit?: CalendarExport | null;
+  templateToEdit?: CalendarExportTemplateChoice | null;
+  onOpenChange: (open: boolean) => void;
+  onSavePersonal?: (input: {
+    id?: string;
+    orgId: string;
+    name: string;
+    config: CalendarExportConfig;
+  }) => Promise<SavedExport | void>;
+  onSaveTemplate?: (input: {
+    id?: string;
+    orgId: string;
+    name: string;
+    description?: string | null;
+    config: CalendarExportConfig;
+  }) => Promise<void>;
+};
+
+const steps = [
+  { id: 'general', label: 'Allgemein' },
+  { id: 'filters', label: 'Filter' },
+  { id: 'preview', label: 'Vorschau' },
+] as const;
+
+function getInitialStepIndex(input: {
+  exportToEdit?: CalendarExport | null;
+  templateToEdit?: CalendarExportTemplateChoice | null;
+}) {
+  return input.exportToEdit || input.templateToEdit ? 1 : 0;
+}
+
+function buildInitialValues(input: {
+  eligibility: CalendarExportEligibility[];
+  initialOrgId?: string | null;
+  exportToEdit?: CalendarExport | null;
+  templateToEdit?: CalendarExportTemplateChoice | null;
+}): FormValues {
+  if (input.exportToEdit) {
+    return {
+      orgId: input.exportToEdit.orgId,
+      name: input.exportToEdit.name,
+      description: '',
+      config: input.exportToEdit.config,
+    };
+  }
+
+  if (input.templateToEdit) {
+    return {
+      orgId: input.templateToEdit.orgId,
+      name: input.templateToEdit.name,
+      description: input.templateToEdit.description ?? '',
+      config: input.templateToEdit.config,
+    };
+  }
+
+  const fallbackOrgId =
+    input.initialOrgId ?? input.eligibility[0]?.organization.id ?? '';
+  return {
+    orgId: fallbackOrgId,
+    name: '',
+    description: '',
+    config: getBlankCalendarExportConfig('helper'),
+  };
+}
+
+function modeLabel(mode: CalendarExportMode) {
+  return mode === 'helper' ? 'Helfer' : 'Verwaltung';
+}
+
+function formatCountLabel(count: number, singular: string, plural: string) {
+  return `${count} passende${count === 1 ? `r ${singular}` : ` ${plural}`}`;
+}
+
+function formatPreviewDate(input: {
+  start: string;
+  end: string;
+  allDay: boolean;
+}) {
+  const start = new Date(input.start);
+  const end = new Date(input.end);
+
+  if (input.allDay) {
+    return start.toLocaleDateString('de-AT', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  }
+
+  return `${start.toLocaleDateString('de-AT', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })}, ${start.toLocaleTimeString('de-AT', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })}-${end.toLocaleTimeString('de-AT', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })}`;
+}
+
+export function CalendarExportDialog(props: CalendarExportDialogProps) {
+  const { eligibility, exportToEdit, initialOrgId, open, templateToEdit } =
+    props;
+  const [stepIndex, setStepIndex] = useState(0);
+  const [savedExport, setSavedExport] = useState<SavedExport | null>(null);
+  const [selectedTemplateId, setSelectedTemplateId] = useState('custom');
+  const [timeWindowDraft, setTimeWindowDraft] = useState({ from: '', to: '' });
+  const [timeWindowErrors, setTimeWindowErrors] = useState<{
+    from: string | null;
+    to: string | null;
+  }>({ from: null, to: null });
+  const { showDestructive } = useConfirmDialog();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: buildInitialValues({
+      eligibility,
+      exportToEdit,
+      initialOrgId,
+      templateToEdit,
+    }),
+  });
+
+  const orgId = useWatch({ control: form.control, name: 'orgId' });
+  const config = useWatch({ control: form.control, name: 'config' });
+  const selectedEligibility = props.eligibility.find(
+    (item) => item.organization.id === orgId
+  );
+  const selectedOrg = selectedEligibility?.organization;
+  const categoriesQuery = useCategories(orgId);
+  const statusesQuery = useStatuses();
+  const templatesQuery = useCompatibleCalendarExportTemplates(
+    props.mode === 'personal' ? orgId : null
+  );
+  const previewQuery = useCalendarExportPreview(orgId, config);
+
+  const availableModes = selectedEligibility?.modes ?? (['helper'] as const);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const initialValues = buildInitialValues({
+      eligibility,
+      exportToEdit,
+      initialOrgId,
+      templateToEdit,
+    });
+    form.reset(initialValues);
+    setTimeWindowDraft({
+      from: initialValues.config.timeWindow?.from ?? '',
+      to: initialValues.config.timeWindow?.to ?? '',
+    });
+    setTimeWindowErrors({ from: null, to: null });
+    setStepIndex(getInitialStepIndex({ exportToEdit, templateToEdit }));
+    setSavedExport(null);
+    setSelectedTemplateId('custom');
+  }, [form, eligibility, exportToEdit, initialOrgId, open, templateToEdit]);
+
+  useEffect(() => {
+    if (!selectedEligibility) {
+      return;
+    }
+
+    if (!selectedEligibility.modes.some((mode) => mode === config.mode)) {
+      form.setValue('config.mode', selectedEligibility.modes[0], {
+        shouldDirty: true,
+      });
+    }
+  }, [selectedEligibility, config.mode, form]);
+
+  const statusOptions = useMemo(() => {
+    const statuses = statusesQuery.data ?? [];
+    if (config.mode === 'verwaltung') {
+      return statuses.map((status) => ({
+        label: status.verwalter_text,
+        ids: [status.id],
+        pseudo: null,
+      }));
+    }
+
+    const grouped = new Map<string, string[]>();
+    statuses.forEach((status) => {
+      const current = grouped.get(status.helper_text) ?? [];
+      current.push(status.id);
+      grouped.set(status.helper_text, current);
+    });
+
+    return [
+      { label: 'Eigene', ids: [], pseudo: 'own' },
+      ...Array.from(grouped.entries()).map(([label, ids]) => ({
+        label,
+        ids,
+        pseudo: null,
+      })),
+    ];
+  }, [statusesQuery.data, config.mode]);
+
+  const categoryOptions = useMemo(
+    () =>
+      (categoriesQuery.data ?? []).map((category) => ({
+        value: category.id,
+        label: category.value,
+      })),
+    [categoriesQuery.data]
+  );
+
+  const applyTemplate = (template: CalendarExportTemplateChoice) => {
+    form.setValue('name', template.name, { shouldDirty: true });
+    form.setValue('config', template.config, { shouldDirty: true });
+    setTimeWindowDraft({
+      from: template.config.timeWindow?.from ?? '',
+      to: template.config.timeWindow?.to ?? '',
+    });
+  };
+
+  const requestClose = async (nextOpen: boolean) => {
+    if (nextOpen) {
+      props.onOpenChange(true);
+      return;
+    }
+
+    if (form.formState.isDirty && !savedExport) {
+      const result = await showDestructive(
+        'Änderungen verwerfen?',
+        'Möchten Sie den Dialog wirklich schließen? Nicht gespeicherte Änderungen gehen verloren.',
+        { confirmText: 'Verwerfen', cancelText: 'Abbrechen' }
+      );
+      if (result !== 'success') {
+        return;
+      }
+    }
+    props.onOpenChange(false);
+  };
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (
+      step.id === 'filters' &&
+      (timeWindowErrors.from ||
+        timeWindowErrors.to ||
+        (config.timeWindow &&
+          ((timeWindowDraft.from && !timeWindowDraft.to) ||
+            (!timeWindowDraft.from && timeWindowDraft.to))))
+    ) {
+      toast.error('Bitte geben Sie eine gültige Start- und Endzeit ein.');
+      return;
+    }
+
+    if (stepIndex < steps.length - 1) {
+      setStepIndex((current) => current + 1);
+      return;
+    }
+
+    await form.handleSubmit(save)();
+  };
+
+  const save = async (values: FormValues) => {
+    if (props.mode === 'personal' && props.onSavePersonal) {
+      const result = await props.onSavePersonal({
+        id: props.exportToEdit?.id,
+        orgId: values.orgId,
+        name: values.name,
+        config: values.config,
+      });
+      if (result) {
+        setSavedExport(result);
+      }
+      form.reset(values);
+      return;
+    }
+
+    if (props.mode === 'template' && props.onSaveTemplate) {
+      await props.onSaveTemplate({
+        id: props.templateToEdit?.id,
+        orgId: values.orgId,
+        name: values.name,
+        description: values.description,
+        config: values.config,
+      });
+      form.reset(values);
+      props.onOpenChange(false);
+    }
+  };
+
+  const copyUrl = async (value: string) => {
+    await navigator.clipboard.writeText(value);
+    toast.success('URL in Zwischenablage kopiert');
+  };
+
+  const setStatusChecked = (
+    option: { ids: string[]; pseudo: string | null },
+    checked: boolean
+  ) => {
+    if (option.pseudo === 'own') {
+      form.setValue('config.statusPseudo', checked ? ['own'] : [], {
+        shouldDirty: true,
+      });
+      return;
+    }
+
+    const selectedIds = new Set(config.statusIds);
+    option.ids.forEach((id) => {
+      if (checked) {
+        selectedIds.add(id);
+      } else {
+        selectedIds.delete(id);
+      }
+    });
+    form.setValue('config.statusIds', Array.from(selectedIds), {
+      shouldDirty: true,
+    });
+  };
+
+  const selectOrg = (value: string) => {
+    const nextEligibility = props.eligibility.find(
+      (item) => item.organization.id === value
+    );
+    form.setValue('orgId', value, { shouldDirty: true });
+    form.setValue(
+      'config',
+      getBlankCalendarExportConfig(nextEligibility?.modes[0] ?? 'helper'),
+      { shouldDirty: true }
+    );
+    setTimeWindowDraft({ from: '', to: '' });
+    form.setValue('name', '', { shouldDirty: true });
+    setSelectedTemplateId('custom');
+  };
+
+  const selectMode = (value: CalendarExportMode) => {
+    form.setValue('config.mode', value, { shouldDirty: true });
+    if (value === 'verwaltung') {
+      form.setValue('config.statusPseudo', [], {
+        shouldDirty: true,
+      });
+    }
+    setSelectedTemplateId('custom');
+  };
+
+  const step = steps[stepIndex];
+
+  return (
+    <Dialog open={props.open} onOpenChange={requestClose}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{step.label}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex gap-2">
+            {steps.map((item, index) => (
+              <div
+                key={item.id}
+                className={cn(
+                  'h-1 flex-1 rounded-full',
+                  index <= stepIndex ? 'bg-primary' : 'bg-muted'
+                )}
+                aria-label={item.label}
+              />
+            ))}
+          </div>
+        </div>
+
+        <form className="space-y-5" onSubmit={submit}>
+          {step.id === 'general' && (
+            <div className="space-y-5">
+              <div className="space-y-2">
+                <Label htmlFor="calendar-export-organization">
+                  Organisation
+                </Label>
+                <Select value={orgId} onValueChange={selectOrg}>
+                  <SelectTrigger id="calendar-export-organization">
+                    <SelectValue placeholder="Organisation auswählen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {props.eligibility.map((item) => (
+                      <SelectItem
+                        key={item.organization.id}
+                        value={item.organization.id}
+                      >
+                        {item.organization.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {props.mode === 'personal' && (
+                <div className="space-y-2">
+                  <Label htmlFor="calendar-export-template">Vorlage</Label>
+                  <Select
+                    value={selectedTemplateId}
+                    onValueChange={(value) => {
+                      setSelectedTemplateId(value);
+
+                      if (value === 'custom') {
+                        form.setValue(
+                          'config',
+                          getBlankCalendarExportConfig(config.mode),
+                          { shouldDirty: true }
+                        );
+                        setTimeWindowDraft({ from: '', to: '' });
+                        form.setValue('name', '', { shouldDirty: true });
+                        return;
+                      }
+
+                      const template = templatesQuery.data?.find(
+                        (item) => item.id === value
+                      );
+                      if (template) {
+                        applyTemplate(template);
+                      }
+                    }}
+                  >
+                    <SelectTrigger id="calendar-export-template">
+                      <SelectValue placeholder="Vorlage auswählen" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="custom">Keine Vorlage</SelectItem>
+                      {templatesQuery.data?.map((template) => (
+                        <SelectItem key={template.id} value={template.id}>
+                          {template.name} · {modeLabel(template.config.mode)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              {availableModes.length > 1 && (
+                <div className="space-y-2">
+                  <Label>Ansicht</Label>
+                  <div className="grid gap-2">
+                    {availableModes.map((mode) => (
+                      <label key={mode} className="flex items-center gap-2">
+                        <Checkbox
+                          checked={config.mode === mode}
+                          onCheckedChange={(checked) => {
+                            if (checked === true) {
+                              selectMode(mode);
+                            }
+                          }}
+                        />
+                        <span>{modeLabel(mode)}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {step.id === 'filters' && (
+            <div className="space-y-5">
+              <div className="rounded-md border p-3 text-sm">
+                {previewQuery.isLoading
+                  ? 'Vorschau wird geladen...'
+                  : formatCountLabel(
+                      previewQuery.data?.count ?? 0,
+                      selectedOrg?.einsatz_name_singular ?? 'Einsatz',
+                      selectedOrg?.einsatz_name_plural ?? 'Einsätze'
+                    )}
+                {previewQuery.data?.trimmedBefore ? (
+                  <p className="text-muted-foreground mt-1">
+                    Ältere vergangene Ereignisse werden zur besseren
+                    Synchronisation nicht exportiert.
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="space-y-1">
+                <Label>Kategorien</Label>
+                {/* Keeps MultiSelect spacing aligned with other form controls. */}
+                <div></div>
+                <MultiSelect
+                  options={categoryOptions}
+                  value={config.categoryIds}
+                  onValueChange={(categoryIds) =>
+                    form.setValue('config.categoryIds', categoryIds, {
+                      shouldDirty: true,
+                    })
+                  }
+                  placeholder={
+                    categoriesQuery.isLoading
+                      ? 'Kategorien werden geladen...'
+                      : 'Kategorien auswählen'
+                  }
+                  emptyState={
+                    categoriesQuery.isLoading
+                      ? 'Kategorien werden geladen...'
+                      : 'Keine Kategorien vorhanden.'
+                  }
+                  maxCount={4}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Status</Label>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <label className="flex items-center gap-2">
+                    <Checkbox
+                      checked={
+                        config.statusIds.length === 0 &&
+                        config.statusPseudo.length === 0
+                      }
+                      onCheckedChange={(checked) => {
+                        if (checked === true) {
+                          form.setValue('config.statusIds', [], {
+                            shouldDirty: true,
+                          });
+                          form.setValue('config.statusPseudo', [], {
+                            shouldDirty: true,
+                          });
+                        }
+                      }}
+                    />
+                    <span>Alle</span>
+                  </label>
+                  {statusOptions.map((option) => {
+                    const checked =
+                      option.pseudo === 'own'
+                        ? config.statusPseudo.includes('own')
+                        : option.ids.every((id) =>
+                            config.statusIds.includes(id)
+                          );
+                    return (
+                      <label
+                        key={`${option.label}-${option.ids.join('-')}`}
+                        className="flex items-center gap-2"
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(nextChecked) =>
+                            setStatusChecked(option, nextChecked === true)
+                          }
+                        />
+                        <span>{option.label}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="space-y-2 pt-4">
+                <div>Fortgeschritten</div>
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.timeWindow !== null}
+                    onCheckedChange={(checked) => {
+                      if (checked === true) {
+                        const from = timeWindowDraft.from || '09:00';
+                        const to = timeWindowDraft.to || '10:00';
+                        setTimeWindowDraft({ from, to });
+                        form.setValue(
+                          'config.timeWindow',
+                          { from, to },
+                          {
+                            shouldDirty: true,
+                          }
+                        );
+                        return;
+                      }
+
+                      setTimeWindowDraft({ from: '', to: '' });
+                      setTimeWindowErrors({ from: null, to: null });
+                      form.setValue('config.timeWindow', null, {
+                        shouldDirty: true,
+                      });
+                    }}
+                  />
+                  <span>Nach Uhrzeit filtern</span>
+                </label>
+                {config.timeWindow ? (
+                  <div className="grid grid-cols-2 gap-3">
+                    <TimeTextInput
+                      id="calendar-export-time-window-from"
+                      invalidMessage="Bitte geben Sie eine gültige Startzeit ein, z. B. 09:30."
+                      value={timeWindowDraft.from}
+                      onValidationChange={(error) =>
+                        setTimeWindowErrors((current) => ({
+                          ...current,
+                          from: error,
+                        }))
+                      }
+                      onValueChange={(from) => {
+                        const to = timeWindowDraft.to;
+                        setTimeWindowDraft({ from, to });
+                        form.setValue(
+                          'config.timeWindow',
+                          { from, to },
+                          {
+                            shouldDirty: true,
+                          }
+                        );
+                      }}
+                    />
+                    <TimeTextInput
+                      id="calendar-export-time-window-to"
+                      invalidMessage="Bitte geben Sie eine gültige Endzeit ein, z. B. 12:20."
+                      value={timeWindowDraft.to}
+                      onValidationChange={(error) =>
+                        setTimeWindowErrors((current) => ({
+                          ...current,
+                          to: error,
+                        }))
+                      }
+                      onValueChange={(to) => {
+                        const from = timeWindowDraft.from;
+                        setTimeWindowDraft({ from, to });
+                        form.setValue(
+                          'config.timeWindow',
+                          { from, to },
+                          {
+                            shouldDirty: true,
+                          }
+                        );
+                      }}
+                    />
+                  </div>
+                ) : null}
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.includeAllDay}
+                    onCheckedChange={(checked) =>
+                      form.setValue('config.includeAllDay', checked === true, {
+                        shouldDirty: true,
+                      })
+                    }
+                  />
+                  <span>Ganztägige Ereignisse einschließen</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.futureOnly}
+                    onCheckedChange={(checked) =>
+                      form.setValue('config.futureOnly', checked === true, {
+                        shouldDirty: true,
+                      })
+                    }
+                  />
+                  <span>Nur zukünftige Ereignisse</span>
+                </label>
+              </div>
+            </div>
+          )}
+
+          {step.id === 'preview' && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="calendar-export-name">
+                  Name Kalenderexport
+                </Label>
+
+                <Input id="calendar-export-name" {...form.register('name')} />
+                {form.formState.errors.name ? (
+                  <p className="text-destructive text-sm">
+                    {form.formState.errors.name.message}
+                  </p>
+                ) : null}
+              </div>
+              {props.mode === 'template' && (
+                <div className="space-y-2">
+                  <Label htmlFor="calendar-export-description">
+                    Beschreibung
+                  </Label>
+                  <Textarea
+                    id="calendar-export-description"
+                    {...form.register('description')}
+                  />
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <Label>Titel-Zusätze</Label>
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.titleAdditions.categories}
+                    onCheckedChange={(checked) =>
+                      form.setValue(
+                        'config.titleAdditions.categories',
+                        checked === true,
+                        { shouldDirty: true }
+                      )
+                    }
+                  />
+                  <span>Kategorien</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.titleAdditions.helperCount}
+                    onCheckedChange={(checked) =>
+                      form.setValue(
+                        'config.titleAdditions.helperCount',
+                        checked === true,
+                        { shouldDirty: true }
+                      )
+                    }
+                  />
+                  <span>Eingetragene/benötigte Helfer:innen</span>
+                </label>
+              </div>
+
+              <div className="rounded-md border px-3 py-2">
+                {previewQuery.isLoading ? (
+                  <p className="text-muted-foreground text-sm">
+                    Vorschau wird geladen...
+                  </p>
+                ) : previewQuery.data?.previewEvents.length ? (
+                  <div className="divide-y">
+                    {previewQuery.data.previewEvents.map((event) => (
+                      <div key={event.id} className="py-2 first:pt-0 last:pb-0">
+                        <p className="font-medium">{event.title}</p>
+                        <p className="text-muted-foreground text-sm">
+                          {formatPreviewDate(event)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    Es gibt kein Ereignis, das mit den aktuellen Filtern
+                    exportiert wird.
+                  </p>
+                )}
+              </div>
+
+              <p className="text-muted-foreground text-sm">
+                {selectedOrg?.name} · {modeLabel(config.mode)}
+              </p>
+              {savedExport ? (
+                <div className="space-y-3 rounded-md border p-3">
+                  <p className="font-medium">Kalender-Link ist bereit</p>
+                  <p className="text-muted-foreground font-mono text-xs break-all">
+                    {savedExport.webcalUrl}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => copyUrl(savedExport.webcalUrl)}
+                    >
+                      <Copy className="mr-2 h-4 w-4" />
+                      Kopieren
+                    </Button>
+                    <Button type="button" variant="outline" asChild>
+                      <a href={savedExport.webcalUrl}>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        In Kalender öffnen
+                      </a>
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                stepIndex === 0
+                  ? requestClose(false)
+                  : setStepIndex((current) => current - 1)
+              }
+            >
+              {stepIndex === 0 ? 'Abbrechen' : 'Zurück'}
+            </Button>
+            {savedExport ? (
+              <Button type="button" onClick={() => props.onOpenChange(false)}>
+                Schließen
+              </Button>
+            ) : (
+              <Button type="submit">
+                {stepIndex === steps.length - 1 ? 'Speichern' : 'Weiter'}
+              </Button>
+            )}
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -335,12 +335,17 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
 
   const save = async (values: FormValues) => {
     if (props.mode === 'personal' && props.onSavePersonal) {
-      const result = await props.onSavePersonal({
-        id: props.exportToEdit?.id,
-        orgId: values.orgId,
-        name: values.name,
-        config: values.config,
-      });
+      let result: SavedExport | void;
+      try {
+        result = await props.onSavePersonal({
+          id: props.exportToEdit?.id,
+          orgId: values.orgId,
+          name: values.name,
+          config: values.config,
+        });
+      } catch {
+        return;
+      }
       if (result) {
         setSavedExport(result);
       }
@@ -349,21 +354,29 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
     }
 
     if (props.mode === 'template' && props.onSaveTemplate) {
-      await props.onSaveTemplate({
-        id: props.templateToEdit?.id,
-        orgId: values.orgId,
-        name: values.name,
-        description: values.description,
-        config: values.config,
-      });
+      try {
+        await props.onSaveTemplate({
+          id: props.templateToEdit?.id,
+          orgId: values.orgId,
+          name: values.name,
+          description: values.description,
+          config: values.config,
+        });
+      } catch {
+        return;
+      }
       form.reset(values);
       props.onOpenChange(false);
     }
   };
 
   const copyUrl = async (value: string) => {
-    await navigator.clipboard.writeText(value);
-    toast.success('URL in Zwischenablage kopiert');
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success('URL in Zwischenablage kopiert');
+    } catch {
+      toast.error('Kopieren fehlgeschlagen');
+    }
   };
 
   const setStatusChecked = (

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -230,7 +230,9 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
     setStepIndex(getInitialStepIndex({ exportToEdit, templateToEdit }));
     setSavedExport(null);
     setSelectedTemplateId('custom');
-  }, [form, eligibility, exportToEdit, initialOrgId, open, templateToEdit]);
+  // Intentionally not depending on `eligibility` to avoid resetting the form while the dialog is open.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form, exportToEdit, initialOrgId, open, templateToEdit]);
 
   useEffect(() => {
     if (!selectedEligibility) {

--- a/src/components/settings/userProfile/CalendarExportGlobalCreate.tsx
+++ b/src/components/settings/userProfile/CalendarExportGlobalCreate.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  useCalendarExportEligibility,
+  useCalendarExports,
+} from '@/features/calendar-subscription/hooks/useCalendarSubscription';
+import { CalendarExportDialog } from './CalendarExportDialog';
+
+export function CalendarExportGlobalCreate({
+  activeOrgId,
+}: {
+  activeOrgId?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const eligibilityQuery = useCalendarExportEligibility();
+  const calendarExports = useCalendarExports();
+  const eligibility = eligibilityQuery.data ?? [];
+
+  if (eligibilityQuery.isLoading || eligibility.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <Plus className="mr-2 h-4 w-4" />
+        Export erstellen
+      </Button>
+      <CalendarExportDialog
+        open={open}
+        mode="personal"
+        eligibility={eligibility}
+        initialOrgId={activeOrgId}
+        onOpenChange={setOpen}
+        onSavePersonal={async (input) => {
+          const result = await calendarExports.createExport.mutateAsync(input);
+          return {
+            name: result.name,
+            webcalUrl: result.webcalUrl,
+            httpUrl: result.httpUrl,
+          };
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/settings/userProfile/CalendarIntegrationCard.tsx
+++ b/src/components/settings/userProfile/CalendarIntegrationCard.tsx
@@ -211,8 +211,12 @@ export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
   );
 
   const copyUrl = async (url: string) => {
-    await navigator.clipboard.writeText(url);
-    toast.success('URL in Zwischenablage kopiert');
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('URL in Zwischenablage kopiert');
+    } catch {
+      toast.error('Kopieren fehlgeschlagen');
+    }
   };
 
   const openCreateDialog = () => {

--- a/src/components/settings/userProfile/CalendarIntegrationCard.tsx
+++ b/src/components/settings/userProfile/CalendarIntegrationCard.tsx
@@ -4,195 +4,459 @@ import {
   Calendar,
   Copy,
   ExternalLink,
+  MoreHorizontal,
+  Pause,
+  Pencil,
+  Play,
+  Plus,
   RefreshCw,
-  Link2Off,
+  Trash2,
 } from 'lucide-react';
+import Image from 'next/image';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { useCalendarSubscription } from '@/features/calendar-subscription/hooks/useCalendarSubscription';
 import TooltipCustom from '@/components/tooltip-custom';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
-import { cn } from '@/lib/utils';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useCategories } from '@/features/einsatz/hooks/useEinsatzQueries';
+import { useStatuses } from '@/features/einsatz_status/hooks/useStatuses';
+import {
+  useCalendarExportEligibility,
+  useCalendarExports,
+  type CalendarExport,
+} from '@/features/calendar-subscription/hooks/useCalendarSubscription';
+import { CalendarExportDialog } from './CalendarExportDialog';
 
 export interface CalendarIntegrationCardProps {
-  org: { id: string; name: string };
+  org: {
+    id: string;
+    name: string;
+    logo_url?: string | null;
+    small_logo_url?: string | null;
+  };
 }
 
-/**
- * Shows the calendar subscription status and actions for one organization.
- */
-export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
-  const { query, rotate, deactivate, activate } = useCalendarSubscription(
-    org.id
-  );
-  const subscription = query.data;
+function modeLabel(mode: string) {
+  return mode === 'verwaltung' ? 'Verwaltung' : 'Helfer';
+}
 
-  const copyUrl = async () => {
-    if (subscription?.webcalUrl) {
-      try {
-        await navigator.clipboard.writeText(subscription.webcalUrl);
-        toast.success('URL in Zwischenablage kopiert');
-      } catch (error) {
-        toast.error(
-          'Fehler beim Kopieren der URL: ' +
-            (error instanceof Error ? error.message : String(error))
+type FilterCategory = {
+  id: string;
+  value: string;
+  abbreviation: string;
+};
+
+type FilterStatus = {
+  id: string;
+  helper_text: string;
+  verwalter_text: string;
+};
+
+type FilterTag = {
+  label: string;
+  tooltip: string;
+};
+
+function buildFilterTags(
+  calendarExport: CalendarExport,
+  categories: FilterCategory[],
+  statuses: FilterStatus[]
+) {
+  const parts: FilterTag[] = [];
+
+  if (calendarExport.config.categoryIds.length > 0) {
+    const categoryLabels = calendarExport.config.categoryIds.map(
+      (categoryId) => {
+        const category = categories.find((item) => item.id === categoryId);
+        return (
+          category?.abbreviation || category?.value || 'Unbekannte Kategorie'
         );
       }
+    );
+    parts.push({
+      label: categoryLabels.join(', '),
+      tooltip: `Kategorien: ${categoryLabels.join(', ')}`,
+    });
+  }
+
+  if (
+    calendarExport.config.statusIds.length > 0 ||
+    calendarExport.config.statusPseudo.length > 0
+  ) {
+    const statusLabels = calendarExport.config.statusIds.map((statusId) => {
+      const status = statuses.find((item) => item.id === statusId);
+      if (!status) {
+        return 'Unbekannter Status';
+      }
+
+      return calendarExport.config.mode === 'helper'
+        ? status.helper_text
+        : status.verwalter_text;
+    });
+
+    if (
+      calendarExport.config.mode === 'helper' &&
+      calendarExport.config.statusPseudo.includes('own')
+    ) {
+      statusLabels.unshift('Eigene');
     }
+
+    const uniqueStatusLabels = Array.from(
+      new Set(statusLabels.filter(Boolean))
+    );
+    parts.push({
+      label: uniqueStatusLabels.join(', '),
+      tooltip: `Status: ${uniqueStatusLabels.join(', ')}`,
+    });
+  }
+
+  if (calendarExport.config.timeWindow) {
+    const timeWindowLabel = `${calendarExport.config.timeWindow.from}-${calendarExport.config.timeWindow.to}`;
+    parts.push({
+      label: timeWindowLabel,
+      tooltip: `Uhrzeit: Ereignisse zwischen ${calendarExport.config.timeWindow.from} und ${calendarExport.config.timeWindow.to}`,
+    });
+
+    if (!calendarExport.config.includeAllDay) {
+      parts.push({
+        label: 'Ohne ganztägige Ereignisse',
+        tooltip: 'Ganztägige Ereignisse werden nicht exportiert.',
+      });
+    }
+  }
+
+  if (calendarExport.config.futureOnly) {
+    parts.push({
+      label: 'Nur zukünftig',
+      tooltip: 'Es werden nur Ereignisse ab heute exportiert.',
+    });
+  }
+
+  return parts;
+}
+
+type CalendarExportTagVariant =
+  | 'active'
+  | 'default'
+  | 'destructive'
+  | 'helper'
+  | 'inactive'
+  | 'verwaltung';
+
+const calendarExportTagClassNames: Record<CalendarExportTagVariant, string> = {
+  active:
+    'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-300',
+  default: 'text-muted-foreground',
+  destructive: 'border-destructive/30 bg-destructive/10 text-destructive',
+  helper:
+    'border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-900/60 dark:bg-cyan-950/40 dark:text-cyan-300',
+  inactive:
+    'border-red-200 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300',
+  verwaltung:
+    'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300',
+};
+
+function CalendarExportTag({
+  children,
+  tooltip,
+  variant = 'default',
+}: {
+  children: React.ReactNode;
+  tooltip?: string;
+  variant?: CalendarExportTagVariant;
+}) {
+  const tag = (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-xs ${calendarExportTagClassNames[variant]}`}
+    >
+      {children}
+    </span>
+  );
+
+  return tooltip ? <TooltipCustom text={tooltip}>{tag}</TooltipCustom> : tag;
+}
+
+export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editExport, setEditExport] = useState<CalendarExport | null>(null);
+  const { showDestructive } = useConfirmDialog();
+  const calendarExports = useCalendarExports();
+  const eligibilityQuery = useCalendarExportEligibility();
+  const categoriesQuery = useCategories(org.id);
+  const statusesQuery = useStatuses();
+  const logoUrl = org.small_logo_url || org.logo_url;
+
+  const eligibility = eligibilityQuery.data ?? [];
+  const orgEligibility = eligibility.find(
+    (item) => item.organization.id === org.id
+  );
+  const exportsForOrg = useMemo(
+    () =>
+      (calendarExports.query.data ?? [])
+        .filter((calendarExport) => calendarExport.orgId === org.id)
+        .sort((left, right) => {
+          if (left.is_active !== right.is_active) {
+            return left.is_active ? -1 : 1;
+          }
+          return left.name.localeCompare(right.name, 'de-AT');
+        }),
+    [calendarExports.query.data, org.id]
+  );
+
+  const copyUrl = async (url: string) => {
+    await navigator.clipboard.writeText(url);
+    toast.success('URL in Zwischenablage kopiert');
   };
 
-  if (query.isLoading) {
+  const openCreateDialog = () => {
+    setEditExport(null);
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (calendarExport: CalendarExport) => {
+    setEditExport(calendarExport);
+    setDialogOpen(true);
+  };
+
+  const deleteExport = async (calendarExport: CalendarExport) => {
+    const result = await showDestructive(
+      'Kalenderexport löschen?',
+      `Möchten Sie den Kalenderexport „${calendarExport.name}“ wirklich löschen? Der bestehende Kalender-Link funktioniert danach nicht mehr.`,
+      { confirmText: 'Löschen', cancelText: 'Abbrechen' }
+    );
+
+    if (result !== 'success') {
+      return;
+    }
+
+    calendarExports.remove.mutate(calendarExport.id);
+  };
+
+  if (calendarExports.query.isLoading || eligibilityQuery.isLoading) {
     return (
       <div className="rounded-lg border p-4">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-10 w-10 rounded-lg" />
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-3 w-48" />
-          </div>
-        </div>
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="mt-3 h-16 w-full" />
       </div>
     );
   }
 
-  if (query.isError) {
-    return (
-      <div className="border-destructive/50 bg-destructive/5 rounded-lg border p-4">
-        <div className="text-destructive flex items-center gap-3">
-          <Calendar className="h-5 w-5" />
-          <div>
-            <p className="font-medium">{org.name}</p>
-            <p className="text-sm">
-              Fehler beim Laden der Kalender-Integration
-            </p>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (!subscription) {
-    return (
-      <div className="rounded-lg border border-dashed p-4">
-        <div className="text-muted-foreground flex items-center gap-3">
-          <Calendar className="h-5 w-5" />
-          <div>
-            <p className="font-medium">{org.name}</p>
-            <p className="text-sm">Keine Kalender-Integration verfügbar</p>
-          </div>
-        </div>
-      </div>
-    );
+  if (!orgEligibility && exportsForOrg.length === 0) {
+    return null;
   }
 
   return (
-    <div className="space-y-4 rounded-lg border p-4">
-      <div className="flex items-start justify-between gap-4">
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Calendar className="text-primary h-5 w-5" />
+          <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg">
+            {logoUrl ? (
+              <Image
+                src={logoUrl}
+                alt={org.name}
+                width={40}
+                height={40}
+                className="h-full w-full object-contain p-1.5"
+              />
+            ) : (
+              <Calendar className="text-muted-foreground h-5 w-5" />
+            )}
           </div>
           <div>
             <h4 className="font-medium">{org.name}</h4>
             <p className="text-muted-foreground text-sm">
-              {subscription.is_active ? 'Aktiv' : 'Deaktiviert'}
+              {exportsForOrg.length === 0
+                ? 'Noch keine Kalenderexporte'
+                : `${exportsForOrg.length} Kalenderexport(e)`}
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {subscription.is_active ? (
-            <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
-              Aktiv
-            </span>
-          ) : (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => {
-                activate.mutate(subscription.id);
-              }}
-              disabled={activate.isPending}
-            >
-              {activate.isPending ? 'Aktiviere...' : 'Aktivieren'}
-            </Button>
-          )}
-        </div>
+        {orgEligibility ? (
+          <Button onClick={openCreateDialog}>
+            <Plus className="mr-2 h-4 w-4" />
+            Export erstellen
+          </Button>
+        ) : null}
       </div>
 
-      <button
-        type="button"
-        className={cn(
-          'group w-full rounded-md p-3 text-left transition-colors',
-          subscription.is_active
-            ? 'bg-muted/50 hover:bg-muted cursor-pointer'
-            : 'bg-muted/30 cursor-default opacity-60'
-        )}
-        onClick={subscription.is_active ? copyUrl : undefined}
-        title={subscription.is_active ? 'Klicken zum Kopieren' : undefined}
-        disabled={!subscription.is_active}
-      >
-        <span className="text-muted-foreground font-mono text-xs break-all">
-          {subscription.webcalUrl}
-        </span>
-      </button>
-
-      {subscription.is_active ? (
-        <div className="flex flex-wrap gap-2">
-          <Button variant="outline" size="sm" onClick={copyUrl}>
-            <Copy className="mr-2 h-3.5 w-3.5" />
-            URL kopieren
-          </Button>
-          <Button variant="outline" size="sm" asChild>
-            <a href={subscription.webcalUrl}>
-              <ExternalLink className="mr-2 h-3.5 w-3.5" />
-              In Kalender öffnen
-            </a>
-          </Button>
-          <TooltipCustom
-            text="Der alte Link wird widerrufen und ein neuer generiert."
-            contentClassName="max-w-xs"
-          >
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                rotate.mutate(subscription.id);
-              }}
-              disabled={rotate.isPending}
-            >
-              <RefreshCw
-                className={cn(
-                  'mr-2 h-3.5 w-3.5',
-                  rotate.isPending && 'animate-spin'
-                )}
-              />
-              {rotate.isPending ? 'Generiere...' : 'Neu generieren'}
-            </Button>
-          </TooltipCustom>
-          <TooltipCustom
-            text="Synchronisation temporär deaktivieren, kann wieder aktiviert werden."
-            contentClassName="max-w-xs"
-          >
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                deactivate.mutate(subscription.id);
-              }}
-              disabled={deactivate.isPending}
-              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            >
-              <Link2Off className="mr-2 h-3.5 w-3.5" />
-              {deactivate.isPending ? 'Deaktiviere...' : 'Deaktivieren'}
-            </Button>
-          </TooltipCustom>
+      {exportsForOrg.length === 0 ? (
+        <div className="bg-muted/40 rounded-md border border-dashed p-5 text-center">
+          <p className="font-medium">Noch keine Kalenderexporte</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Erstellen Sie einen Export, um ihn in Ihrer Kalender-App zu
+            abonnieren.
+          </p>
         </div>
       ) : (
-        <p className="text-muted-foreground text-sm">
-          Die Kalender-Integration ist deaktiviert. Aktivieren Sie sie, um die
-          Synchronisation wieder zu starten.
-        </p>
+        <div className="space-y-2">
+          {exportsForOrg.map((calendarExport) => {
+            const filterTags = buildFilterTags(
+              calendarExport,
+              categoriesQuery.data ?? [],
+              statusesQuery.data ?? []
+            ).filter(Boolean);
+
+            return (
+              <div
+                key={calendarExport.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-medium">{calendarExport.name}</p>
+                    <CalendarExportTag
+                      variant={calendarExport.is_active ? 'active' : 'inactive'}
+                    >
+                      {calendarExport.is_active ? 'Aktiv' : 'Deaktiviert'}
+                    </CalendarExportTag>
+                    <CalendarExportTag
+                      variant={
+                        calendarExport.config.mode === 'verwaltung'
+                          ? 'verwaltung'
+                          : 'helper'
+                      }
+                    >
+                      {modeLabel(calendarExport.config.mode)}
+                    </CalendarExportTag>
+                    {filterTags.map((filterTag) => (
+                      <CalendarExportTag
+                        key={`${filterTag.tooltip}-${filterTag.label}`}
+                        tooltip={filterTag.tooltip}
+                      >
+                        {filterTag.label}
+                      </CalendarExportTag>
+                    ))}
+                    {!calendarExport.modeAvailable ? (
+                      <CalendarExportTag variant="destructive">
+                        Zugriff fehlt
+                      </CalendarExportTag>
+                    ) : null}
+                  </div>
+                  {calendarExport.last_accessed ? (
+                    <p className="text-muted-foreground mt-1 text-xs">
+                      Zuletzt abgerufen:{' '}
+                      {new Date(
+                        calendarExport.last_accessed
+                      ).toLocaleDateString('de-AT')}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => openEditDialog(calendarExport)}
+                  >
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Bearbeiten
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    asChild
+                    className={
+                      !calendarExport.is_active
+                        ? 'pointer-events-none opacity-50'
+                        : ''
+                    }
+                  >
+                    <a href={calendarExport.webcalUrl}>
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      Kalender verbinden
+                    </a>
+                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon">
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => copyUrl(calendarExport.webcalUrl)}
+                        disabled={!calendarExport.is_active}
+                      >
+                        <Copy className="mr-2 h-4 w-4" />
+                        Link kopieren
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() =>
+                          calendarExports.rotate.mutate(calendarExport.id)
+                        }
+                      >
+                        <RefreshCw className="mr-2 h-4 w-4" />
+                        Link neu generieren
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() =>
+                          calendarExports.setActive.mutate({
+                            id: calendarExport.id,
+                            isActive: !calendarExport.is_active,
+                          })
+                        }
+                      >
+                        {calendarExport.is_active ? (
+                          <Pause className="mr-2 h-4 w-4" />
+                        ) : (
+                          <Play className="mr-2 h-4 w-4" />
+                        )}
+                        {calendarExport.is_active
+                          ? 'Deaktivieren'
+                          : 'Aktivieren'}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="text-destructive"
+                        onClick={() => deleteExport(calendarExport)}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Löschen
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       )}
+
+      <CalendarExportDialog
+        open={dialogOpen}
+        mode="personal"
+        eligibility={eligibility}
+        initialOrgId={org.id}
+        exportToEdit={editExport}
+        onOpenChange={setDialogOpen}
+        onSavePersonal={async (input) => {
+          if (input.id && input.orgId === editExport?.orgId) {
+            const result = await calendarExports.updateExport.mutateAsync({
+              id: input.id,
+              orgId: input.orgId,
+              name: input.name,
+              config: input.config,
+            });
+            return {
+              name: result.name,
+              webcalUrl: result.webcalUrl,
+              httpUrl: result.httpUrl,
+            };
+          }
+
+          const result = await calendarExports.createExport.mutateAsync(input);
+          return {
+            name: result.name,
+            webcalUrl: result.webcalUrl,
+            httpUrl: result.httpUrl,
+          };
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -83,6 +83,7 @@ const DialogContent = React.forwardRef<
     </DialogPortal>
   );
 });
+DialogContent.displayName = 'DialogContent';
 
 function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/src/features/auth/actions.test.ts
+++ b/src/features/auth/actions.test.ts
@@ -140,6 +140,9 @@ describe('createSelfSignupAction', () => {
           role: {
             findMany: ReturnType<typeof vi.fn>;
           };
+          calendar_export_template: {
+            createMany: ReturnType<typeof vi.fn>;
+          };
         }) => Promise<unknown>
       ) =>
         callback({
@@ -156,6 +159,9 @@ describe('createSelfSignupAction', () => {
           },
           role: {
             findMany: mockRoleFindMany,
+          },
+          calendar_export_template: {
+            createMany: vi.fn(),
           },
         })
     );

--- a/src/features/auth/actions.ts
+++ b/src/features/auth/actions.ts
@@ -21,6 +21,7 @@ import { authOptions } from '@/lib/auth.config';
 import { actionClient } from '@/lib/safe-action';
 import { formSchema as registerFormSchema } from './register-schema';
 import prisma from '@/lib/prisma';
+import { seedDefaultCalendarExportTemplatesForOrg } from '@/features/calendar-subscription/calendarSubscription';
 import {
   createAndSendOneTimePasswordChallenge,
   consumeVerifiedOneTimePasswordChallenge,
@@ -38,11 +39,17 @@ const forgotPasswordSchema = z.object({
 });
 
 const sendOneTimePasswordSchema = z.object({
-  email: z.string().trim().email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
+  email: z
+    .string()
+    .trim()
+    .email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
 });
 
 const verifyOneTimePasswordSchema = z.object({
-  email: z.string().trim().email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
+  email: z
+    .string()
+    .trim()
+    .email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
   code: z
     .string()
     .trim()
@@ -50,7 +57,10 @@ const verifyOneTimePasswordSchema = z.object({
 });
 
 const getSelfSignupAccountStatusSchema = z.object({
-  email: z.string().trim().email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
+  email: z
+    .string()
+    .trim()
+    .email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
 });
 
 const optionalOrganizationPhoneSchema = z
@@ -93,14 +103,24 @@ const createSelfSignupSchema = z.discriminatedUnion('accountMode', [
     accountMode: z.literal('new'),
     firstName: z.string().trim().min(1, 'Der Vorname ist erforderlich'),
     lastName: z.string().trim().min(1, 'Der Nachname ist erforderlich'),
-    email: z.string().trim().email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
-    password: z.string().min(8, 'Das Passwort muss mindestens 8 Zeichen lang sein.'),
+    email: z
+      .string()
+      .trim()
+      .email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
+    password: z
+      .string()
+      .min(8, 'Das Passwort muss mindestens 8 Zeichen lang sein.'),
     challengeId: z.string().uuid('Die Bestätigung ist ungültig.'),
   }),
   selfSignupOrganizationSchema.extend({
     accountMode: z.literal('existing'),
-    email: z.string().trim().email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
-    password: z.string().min(8, 'Das Passwort muss mindestens 8 Zeichen lang sein.'),
+    email: z
+      .string()
+      .trim()
+      .email('Bitte geben Sie eine gültige E-Mail-Adresse ein'),
+    password: z
+      .string()
+      .min(8, 'Das Passwort muss mindestens 8 Zeichen lang sein.'),
   }),
   selfSignupOrganizationSchema.extend({
     accountMode: z.literal('logged_in'),
@@ -139,6 +159,8 @@ async function createSelfSignupOrganization(
     });
   }
 
+  await seedDefaultCalendarExportTemplatesForOrg(organization.id, tx);
+
   return organization;
 }
 
@@ -148,7 +170,9 @@ async function getAssignableRoleIds(tx: Prisma.TransactionClient) {
   });
 
   if (assignableRoles.length === 0) {
-    throw new Error('Es konnten keine Rollen für die neue Organisation gefunden werden.');
+    throw new Error(
+      'Es konnten keine Rollen für die neue Organisation gefunden werden.'
+    );
   }
 
   return assignableRoles.map((role) => role.id);
@@ -446,7 +470,10 @@ export const createSelfSignupAction = actionClient
           tx
         );
 
-        const organization = await createSelfSignupOrganization(tx, parsedInput);
+        const organization = await createSelfSignupOrganization(
+          tx,
+          parsedInput
+        );
         const roleIds = await getAssignableRoleIds(tx);
 
         await tx.user.create({
@@ -468,7 +495,8 @@ export const createSelfSignupAction = actionClient
         return {
           organization,
           notificationContext: {
-            creatorName: `${parsedInput.firstName} ${parsedInput.lastName}`.trim(),
+            creatorName:
+              `${parsedInput.firstName} ${parsedInput.lastName}`.trim(),
             creatorEmail: normalizedEmail,
           },
         };
@@ -502,8 +530,15 @@ export const createSelfSignupAction = actionClient
           throw new Error('Das eingegebene Passwort ist nicht korrekt.');
         }
 
-        const organization = await createSelfSignupOrganization(tx, parsedInput);
-        await addUserToOrganizationWithAllRoles(tx, existingUser.id, organization.id);
+        const organization = await createSelfSignupOrganization(
+          tx,
+          parsedInput
+        );
+        await addUserToOrganizationWithAllRoles(
+          tx,
+          existingUser.id,
+          organization.id
+        );
         return {
           organization,
           notificationContext: {
@@ -533,7 +568,10 @@ export const createSelfSignupAction = actionClient
           },
         });
 
-        const organization = await createSelfSignupOrganization(tx, parsedInput);
+        const organization = await createSelfSignupOrganization(
+          tx,
+          parsedInput
+        );
         await addUserToOrganizationWithAllRoles(
           tx,
           session.user.id,

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -1,7 +1,9 @@
 'use server';
 
+import { startOfDay } from 'date-fns';
 import { getServerSession } from 'next-auth';
 import { z } from 'zod';
+import type { Prisma } from '@/generated/prisma';
 import { authOptions } from '@/lib/auth.config';
 import { hasPermission } from '@/lib/auth/authGuard';
 import prisma from '@/lib/prisma';
@@ -36,6 +38,47 @@ const exportInputSchema = z.object({
 const templateInputSchema = exportInputSchema.extend({
   description: z.string().trim().optional().nullable(),
 });
+
+function buildCalendarExportPreviewWhere(
+  orgId: string,
+  config: CalendarExportConfig,
+  ownerUserId: string
+): Prisma.einsatzWhereInput {
+  const where: Prisma.einsatzWhereInput = { org_id: orgId };
+
+  if (config.futureOnly) {
+    where.end = { gte: startOfDay(new Date()) };
+  }
+
+  if (!config.includeAllDay) {
+    where.all_day = false;
+  }
+
+  if (config.categoryIds.length > 0) {
+    where.einsatz_to_category = {
+      some: {
+        category_id: { in: config.categoryIds },
+      },
+    };
+  }
+
+  const statusBranches: Prisma.einsatzWhereInput[] = [];
+  if (config.statusIds.length > 0) {
+    statusBranches.push({ status_id: { in: config.statusIds } });
+  }
+  if (config.mode === 'helper' && config.statusPseudo.includes('own')) {
+    statusBranches.push({
+      einsatz_helper: {
+        some: { user_id: ownerUserId },
+      },
+    });
+  }
+  if (statusBranches.length > 0) {
+    where.OR = statusBranches;
+  }
+
+  return where;
+}
 
 async function checkUserSession() {
   const session = await getServerSession(authOptions);
@@ -432,9 +475,12 @@ export async function getCalendarExportPreviewAction(
   await validateConfigReferences(orgId, parsedConfig);
 
   const events = await prisma.einsatz.findMany({
-    where: { org_id: orgId },
+    where: buildCalendarExportPreviewWhere(
+      orgId,
+      parsedConfig,
+      session.user.id
+    ),
     orderBy: { start: 'asc' },
-    take: 1000,
     select: {
       id: true,
       title: true,

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -133,18 +133,18 @@ async function validateConfigReferences(
     config.categoryIds.length === 0
       ? Promise.resolve(0)
       : prisma.einsatz_category.count({
-          where: {
-            id: { in: config.categoryIds },
-            org_id: orgId,
-          },
-        }),
+        where: {
+          id: { in: config.categoryIds },
+          org_id: orgId,
+        },
+      }),
     config.statusIds.length === 0
       ? Promise.resolve(0)
       : prisma.einsatz_status.count({
-          where: {
-            id: { in: config.statusIds },
-          },
-        }),
+        where: {
+          id: { in: config.statusIds },
+        },
+      }),
   ]);
 
   if (categoryCount !== new Set(config.categoryIds).size) {

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -1,15 +1,41 @@
 'use server';
 
 import { getServerSession } from 'next-auth';
+import { z } from 'zod';
 import { authOptions } from '@/lib/auth.config';
+import { hasPermission } from '@/lib/auth/authGuard';
+import prisma from '@/lib/prisma';
 import {
-  getOrCreateCalendarSubscription,
-  rotateCalendarSubscription,
-  deactivateCalendarSubscription,
-  activateCalendarSubscription,
   buildCalendarSubscriptionUrl,
   buildWebcalUrl,
+  createCalendarExport,
+  createCalendarExportTemplate,
+  deleteCalendarExport,
+  deleteCalendarExportTemplate,
+  listCalendarExports,
+  listCalendarExportTemplates,
+  rotateCalendarSubscription,
+  setCalendarExportActive,
+  updateCalendarExport,
+  updateCalendarExportTemplate,
 } from './calendarSubscription';
+import {
+  calendarExportConfigSchema,
+  parseCalendarExportConfig,
+  type CalendarExportConfig,
+  type CalendarExportMode,
+} from './config';
+import { filterCalendarExportEvents } from './filter';
+import { composeCalendarExportEventTitle } from './title';
+
+const exportInputSchema = z.object({
+  name: z.string().trim().min(1, 'Der Name ist erforderlich.'),
+  config: calendarExportConfigSchema,
+});
+
+const templateInputSchema = exportInputSchema.extend({
+  description: z.string().trim().optional().nullable(),
+});
 
 async function checkUserSession() {
   const session = await getServerSession(authOptions);
@@ -17,24 +43,243 @@ async function checkUserSession() {
   return session;
 }
 
-export async function getSubscriptionAction(orgId: string) {
+async function assertReadAccess(orgId: string) {
   const session = await checkUserSession();
+  if (!(await hasPermission(session, 'einsaetze:read', orgId))) {
+    throw new Error(
+      'Keine Berechtigung für Kalenderexporte dieser Organisation.'
+    );
+  }
+  return session;
+}
 
-  const response = await getOrCreateCalendarSubscription(
+async function assertOrganizationUpdateAccess(orgId: string) {
+  const session = await checkUserSession();
+  if (!(await hasPermission(session, 'organization:update', orgId))) {
+    throw new Error(
+      'Keine Berechtigung, Kalenderexport-Vorlagen dieser Organisation zu bearbeiten.'
+    );
+  }
+  return session;
+}
+
+async function hasManagementModeAccess(orgId: string) {
+  const session = await checkUserSession();
+  return (
+    (await hasPermission(session, 'einsaetze:create', orgId)) ||
+    (await hasPermission(session, 'einsaetze:update', orgId)) ||
+    (await hasPermission(session, 'einsaetze:delete', orgId))
+  );
+}
+
+async function assertModeAccess(orgId: string, mode: CalendarExportMode) {
+  if (mode === 'helper') {
+    return;
+  }
+
+  if (!(await hasManagementModeAccess(orgId))) {
+    throw new Error('Keine Berechtigung für Kalenderexporte der Verwaltung.');
+  }
+}
+
+async function validateConfigReferences(
+  orgId: string,
+  config: CalendarExportConfig
+) {
+  const [categoryCount, statusCount] = await Promise.all([
+    config.categoryIds.length === 0
+      ? Promise.resolve(0)
+      : prisma.einsatz_category.count({
+          where: {
+            id: { in: config.categoryIds },
+            org_id: orgId,
+          },
+        }),
+    config.statusIds.length === 0
+      ? Promise.resolve(0)
+      : prisma.einsatz_status.count({
+          where: {
+            id: { in: config.statusIds },
+          },
+        }),
+  ]);
+
+  if (categoryCount !== new Set(config.categoryIds).size) {
+    throw new Error(
+      'Mindestens eine Kategorie gehört nicht zu dieser Organisation.'
+    );
+  }
+
+  if (statusCount !== new Set(config.statusIds).size) {
+    throw new Error('Mindestens ein Status ist nicht verfügbar.');
+  }
+
+  if (config.mode === 'verwaltung' && config.statusPseudo.includes('own')) {
+    throw new Error('Eigene Einsätze sind nur in der Helferansicht verfügbar.');
+  }
+}
+
+function toCalendarExportResponse(
+  calendarExport: Awaited<ReturnType<typeof listCalendarExports>>[number],
+  managementModeAvailable: boolean
+) {
+  return {
+    id: calendarExport.id,
+    orgId: calendarExport.org_id,
+    organization: calendarExport.organization,
+    name: calendarExport.name ?? 'Kalenderexport',
+    is_active: calendarExport.is_active,
+    token: calendarExport.token,
+    webcalUrl: buildWebcalUrl(calendarExport.token),
+    httpUrl: buildCalendarSubscriptionUrl(calendarExport.token),
+    last_accessed: calendarExport.last_accessed?.toISOString() ?? null,
+    created_at: calendarExport.created_at.toISOString(),
+    config: calendarExport.parsedConfig,
+    modeAvailable:
+      calendarExport.parsedConfig.mode === 'helper' || managementModeAvailable,
+  };
+}
+
+export async function listCalendarExportsAction() {
+  const session = await checkUserSession();
+  const calendarExports = await listCalendarExports(session.user.id);
+  const readableOrgIds = new Set<string>();
+  const managementOrgIds = new Set<string>();
+
+  await Promise.all(
+    Array.from(new Set(calendarExports.map((item) => item.org_id))).map(
+      async (orgId) => {
+        if (await hasPermission(session, 'einsaetze:read', orgId)) {
+          readableOrgIds.add(orgId);
+        }
+        if (
+          (await hasPermission(session, 'einsaetze:create', orgId)) ||
+          (await hasPermission(session, 'einsaetze:update', orgId)) ||
+          (await hasPermission(session, 'einsaetze:delete', orgId))
+        ) {
+          managementOrgIds.add(orgId);
+        }
+      }
+    )
+  );
+
+  return calendarExports
+    .filter((calendarExport) => readableOrgIds.has(calendarExport.org_id))
+    .map((calendarExport) =>
+      toCalendarExportResponse(
+        calendarExport,
+        managementOrgIds.has(calendarExport.org_id)
+      )
+    );
+}
+
+export async function listCalendarExportEligibilityAction() {
+  const session = await checkUserSession();
+  const orgIds = session.user.orgIds ?? [];
+
+  const organizations = await prisma.organization.findMany({
+    where: {
+      id: { in: orgIds },
+    },
+    select: {
+      id: true,
+      name: true,
+      helper_name_singular: true,
+      helper_name_plural: true,
+      einsatz_name_singular: true,
+      einsatz_name_plural: true,
+    },
+    orderBy: { name: 'asc' },
+  });
+
+  const eligibility = await Promise.all(
+    organizations.map(async (organization) => {
+      const canRead = await hasPermission(
+        session,
+        'einsaetze:read',
+        organization.id
+      );
+
+      if (!canRead) {
+        return null;
+      }
+
+      const canUseManagementMode =
+        (await hasPermission(session, 'einsaetze:create', organization.id)) ||
+        (await hasPermission(session, 'einsaetze:update', organization.id)) ||
+        (await hasPermission(session, 'einsaetze:delete', organization.id));
+
+      return {
+        organization,
+        modes: canUseManagementMode
+          ? (['helper', 'verwaltung'] as const)
+          : (['helper'] as const),
+      };
+    })
+  );
+
+  return eligibility.filter(
+    (item): item is NonNullable<(typeof eligibility)[number]> => item !== null
+  );
+}
+
+export async function createCalendarExportAction(
+  orgId: string,
+  input: z.input<typeof exportInputSchema>
+) {
+  const session = await assertReadAccess(orgId);
+  const parsedInput = exportInputSchema.parse(input);
+  await assertModeAccess(orgId, parsedInput.config.mode);
+  await validateConfigReferences(orgId, parsedInput.config);
+
+  const calendarExport = await createCalendarExport({
+    userId: session.user.id,
     orgId,
-    session.user.id
-  ).catch(() => {
-    throw new Error('Die Kalenderintegration konnte nicht geladen werden.');
+    name: parsedInput.name,
+    config: parsedInput.config,
   });
 
   return {
-    id: response.id,
-    name: response.name ?? '',
-    is_active: response.is_active,
-    token: response.token,
-    webcalUrl: buildWebcalUrl(response.token),
-    httpUrl: buildCalendarSubscriptionUrl(response.token),
-    last_accessed: response.last_accessed?.toString() ?? null,
+    id: calendarExport.id,
+    name: calendarExport.name ?? '',
+    token: calendarExport.token,
+    webcalUrl: buildWebcalUrl(calendarExport.token),
+    httpUrl: buildCalendarSubscriptionUrl(calendarExport.token),
+  };
+}
+
+export async function updateCalendarExportAction(
+  id: string,
+  input: z.input<typeof exportInputSchema>
+) {
+  const session = await checkUserSession();
+  const existing = await prisma.calendar_subscription.findFirst({
+    where: { id, user_id: session.user.id },
+    select: { org_id: true },
+  });
+
+  if (!existing) {
+    throw new Error('Kalenderexport wurde nicht gefunden.');
+  }
+
+  await assertReadAccess(existing.org_id);
+  const parsedInput = exportInputSchema.parse(input);
+  await assertModeAccess(existing.org_id, parsedInput.config.mode);
+  await validateConfigReferences(existing.org_id, parsedInput.config);
+
+  const calendarExport = await updateCalendarExport({
+    id,
+    userId: session.user.id,
+    name: parsedInput.name,
+    config: parsedInput.config,
+  });
+
+  return {
+    id: calendarExport.id,
+    name: calendarExport.name ?? '',
+    token: calendarExport.token,
+    webcalUrl: buildWebcalUrl(calendarExport.token),
+    httpUrl: buildCalendarSubscriptionUrl(calendarExport.token),
   };
 }
 
@@ -42,7 +287,7 @@ export async function rotateSubscriptionAction(id: string) {
   const session = await checkUserSession();
   const response = await rotateCalendarSubscription(id, session.user.id).catch(
     () => {
-      throw new Error('Der API-Schlüssel konnte nicht rotiert werden.');
+      throw new Error('Der Kalender-Link konnte nicht neu generiert werden.');
     }
   );
 
@@ -54,14 +299,21 @@ export async function rotateSubscriptionAction(id: string) {
   };
 }
 
-export async function deactivateSubscriptionAction(id: string) {
+export async function setCalendarExportActiveAction(
+  id: string,
+  isActive: boolean
+) {
   const session = await checkUserSession();
-
-  const response = await deactivateCalendarSubscription(
+  const response = await setCalendarExportActive({
     id,
-    session.user.id
-  ).catch(() => {
-    throw new Error('Die Kalenderintegration konnte nicht deaktiviert werden.');
+    userId: session.user.id,
+    isActive,
+  }).catch(() => {
+    throw new Error(
+      isActive
+        ? 'Der Kalenderexport konnte nicht aktiviert werden.'
+        : 'Der Kalenderexport konnte nicht deaktiviert werden.'
+    );
   });
 
   return {
@@ -70,18 +322,168 @@ export async function deactivateSubscriptionAction(id: string) {
   };
 }
 
-export async function activateSubscriptionAction(id: string) {
+export async function deleteCalendarExportAction(id: string) {
   const session = await checkUserSession();
+  await deleteCalendarExport(id, session.user.id);
+  return { id };
+}
 
-  const response = await activateCalendarSubscription(
-    id,
-    session.user.id
-  ).catch(() => {
-    throw new Error('Die Kalenderintegration konnte nicht aktiviert werden.');
+export async function listCalendarExportTemplatesAction(orgId: string) {
+  await assertOrganizationUpdateAccess(orgId);
+  const templates = await listCalendarExportTemplates(orgId);
+  return templates.map((template) => ({
+    id: template.id,
+    orgId: template.org_id,
+    name: template.name,
+    description: template.description,
+    config: template.parsedConfig,
+    created_at: template.created_at.toISOString(),
+    updated_at: template.updated_at?.toISOString() ?? null,
+  }));
+}
+
+export async function listCompatibleCalendarExportTemplatesAction(
+  orgId: string
+) {
+  await assertReadAccess(orgId);
+  const managementModeAvailable = await hasManagementModeAccess(orgId);
+  const templates = await listCalendarExportTemplates(orgId);
+
+  return templates
+    .filter(
+      (template) =>
+        template.parsedConfig.mode === 'helper' || managementModeAvailable
+    )
+    .map((template) => ({
+      id: template.id,
+      orgId: template.org_id,
+      name: template.name,
+      description: template.description,
+      config: template.parsedConfig,
+    }));
+}
+
+export async function createCalendarExportTemplateAction(
+  orgId: string,
+  input: z.input<typeof templateInputSchema>
+) {
+  await assertOrganizationUpdateAccess(orgId);
+  const parsedInput = templateInputSchema.parse(input);
+  await validateConfigReferences(orgId, parsedInput.config);
+
+  const template = await createCalendarExportTemplate({
+    orgId,
+    name: parsedInput.name,
+    description: parsedInput.description,
+    config: parsedInput.config,
   });
 
   return {
-    id: response.id,
-    is_active: response.is_active,
+    id: template.id,
+    orgId: template.org_id,
+    name: template.name,
+    description: template.description,
+    config: parseCalendarExportConfig(template.config),
+  };
+}
+
+export async function updateCalendarExportTemplateAction(
+  orgId: string,
+  id: string,
+  input: z.input<typeof templateInputSchema>
+) {
+  await assertOrganizationUpdateAccess(orgId);
+  const parsedInput = templateInputSchema.parse(input);
+  await validateConfigReferences(orgId, parsedInput.config);
+
+  const template = await updateCalendarExportTemplate({
+    id,
+    orgId,
+    name: parsedInput.name,
+    description: parsedInput.description,
+    config: parsedInput.config,
+  });
+
+  return {
+    id: template.id,
+    orgId: template.org_id,
+    name: template.name,
+    description: template.description,
+    config: parseCalendarExportConfig(template.config),
+  };
+}
+
+export async function deleteCalendarExportTemplateAction(
+  orgId: string,
+  id: string
+) {
+  await assertOrganizationUpdateAccess(orgId);
+  await deleteCalendarExportTemplate(id, orgId);
+  return { id };
+}
+
+export async function getCalendarExportPreviewAction(
+  orgId: string,
+  config: unknown
+) {
+  const session = await assertReadAccess(orgId);
+  const parsedConfig = calendarExportConfigSchema.parse(config);
+  await assertModeAccess(orgId, parsedConfig.mode);
+  await validateConfigReferences(orgId, parsedConfig);
+
+  const events = await prisma.einsatz.findMany({
+    where: { org_id: orgId },
+    orderBy: { start: 'asc' },
+    select: {
+      id: true,
+      title: true,
+      start: true,
+      end: true,
+      all_day: true,
+      status_id: true,
+      helpers_needed: true,
+      einsatz_to_category: {
+        select: {
+          category_id: true,
+          einsatz_category: {
+            select: {
+              id: true,
+              abbreviation: true,
+            },
+          },
+        },
+      },
+      einsatz_helper: {
+        select: {
+          user_id: true,
+        },
+      },
+    },
+  });
+
+  const result = filterCalendarExportEvents(
+    events,
+    parsedConfig,
+    session.user.id
+  );
+
+  return {
+    count: result.events.length,
+    trimmedBefore: result.trimmedBefore?.toISOString() ?? null,
+    previewEvents: result.events.slice(0, 5).map((event) => ({
+      id: event.id,
+      title: composeCalendarExportEventTitle({
+        title: event.title,
+        categoryAbbreviations: event.einsatz_to_category
+          .map((category) => category.einsatz_category.abbreviation)
+          .filter((abbreviation) => abbreviation !== ''),
+        assignedHelpers: event.einsatz_helper.length,
+        helpersNeeded: event.helpers_needed,
+        config: parsedConfig,
+      }),
+      start: event.start.toISOString(),
+      end: event.end.toISOString(),
+      allDay: event.all_day,
+    })),
   };
 }

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -434,6 +434,7 @@ export async function getCalendarExportPreviewAction(
   const events = await prisma.einsatz.findMany({
     where: { org_id: orgId },
     orderBy: { start: 'asc' },
+    take: 1000,
     select: {
       id: true,
       title: true,

--- a/src/features/calendar-subscription/calendarSubscription.ts
+++ b/src/features/calendar-subscription/calendarSubscription.ts
@@ -2,14 +2,11 @@ import type { Prisma } from '@/generated/prisma';
 import prisma from '@/lib/prisma';
 import { generatedToken } from '@/lib/token';
 import {
-  createOpenFutureTemplateConfig,
   createOwnFutureTemplateConfig,
   getBlankCalendarExportConfig,
   parseCalendarExportConfig,
   type CalendarExportConfig,
 } from './config';
-
-const OPEN_STATUS_ID = 'bb169357-920b-4b49-9e3d-1cf489409370';
 
 type CalendarSubscriptionExecutor = Pick<
   typeof prisma,
@@ -266,9 +263,12 @@ export async function seedDefaultCalendarExportTemplatesForOrg(
     data: [
       {
         org_id: orgId,
-        name: 'Nur offene in der Zukunft',
+        name: 'Alle zukünftigen Ereignisse',
         description: null,
-        config: toJsonInput(createOpenFutureTemplateConfig(OPEN_STATUS_ID)),
+        config: toJsonInput({
+          ...getBlankCalendarExportConfig('helper'),
+          futureOnly: true,
+        }),
       },
       {
         org_id: orgId,
@@ -278,13 +278,13 @@ export async function seedDefaultCalendarExportTemplatesForOrg(
       },
       {
         org_id: orgId,
-        name: 'Alle Ereignisse',
+        name: 'Alle Ereignisse (Helfer)',
         description: null,
         config: toJsonInput(getBlankCalendarExportConfig('helper')),
       },
       {
         org_id: orgId,
-        name: 'Alle Ereignisse',
+        name: 'Alle Ereignisse (Verwaltung)',
         description: null,
         config: toJsonInput(getBlankCalendarExportConfig('verwaltung')),
       },

--- a/src/features/calendar-subscription/calendarSubscription.ts
+++ b/src/features/calendar-subscription/calendarSubscription.ts
@@ -1,40 +1,186 @@
+import type { Prisma } from '@/generated/prisma';
 import prisma from '@/lib/prisma';
 import { generatedToken } from '@/lib/token';
+import {
+  createOpenFutureTemplateConfig,
+  createOwnFutureTemplateConfig,
+  getBlankCalendarExportConfig,
+  parseCalendarExportConfig,
+  type CalendarExportConfig,
+} from './config';
 
-export async function getOrCreateCalendarSubscription(
-  orgId: string,
-  userId: string
-) {
-  if (!orgId || !userId) {
-    throw new Error('Organisation oder Benutzer konnte nicht zugeordnet werden.');
+const OPEN_STATUS_ID = 'bb169357-920b-4b49-9e3d-1cf489409370';
+
+type CalendarSubscriptionExecutor = Pick<
+  typeof prisma,
+  'calendar_subscription' | 'organization' | 'einsatz_status'
+>;
+
+type CalendarTemplateExecutor = Pick<typeof prisma, 'calendar_export_template'>;
+
+function toJsonInput(config: CalendarExportConfig): Prisma.InputJsonValue {
+  return config as unknown as Prisma.InputJsonValue;
+}
+
+function normalizeName(value: string) {
+  return value.trim().toLocaleLowerCase('de-AT');
+}
+
+function appendNameSuffix(baseName: string, suffix: number) {
+  return `${baseName} ${suffix}`;
+}
+
+export async function createUniqueCalendarExportName(input: {
+  userId: string;
+  orgId: string;
+  requestedName: string;
+}) {
+  const baseName = input.requestedName.trim();
+  if (!baseName) {
+    throw new Error('Der Name ist erforderlich.');
   }
 
-  const existingCalendarSubscription =
-    await prisma.calendar_subscription.findFirst({
-      where: { org_id: orgId, user_id: userId, is_active: true },
-    });
-  if (existingCalendarSubscription) {
-    return existingCalendarSubscription;
-  }
-  const organization = await prisma.organization.findUnique({
-    where: { id: orgId },
+  const existingExports = await prisma.calendar_subscription.findMany({
+    where: {
+      user_id: input.userId,
+      org_id: input.orgId,
+    },
     select: { name: true },
+  });
+
+  const existingNames = new Set(
+    existingExports
+      .map((calendarExport) => calendarExport.name)
+      .filter((name): name is string => Boolean(name))
+      .map(normalizeName)
+  );
+
+  if (!existingNames.has(normalizeName(baseName))) {
+    return baseName;
+  }
+
+  let suffix = 2;
+  while (existingNames.has(normalizeName(appendNameSuffix(baseName, suffix)))) {
+    suffix += 1;
+  }
+
+  return appendNameSuffix(baseName, suffix);
+}
+
+export async function calendarExportNameExists(input: {
+  userId: string;
+  orgId: string;
+  name: string;
+  excludeId?: string;
+}) {
+  const normalizedRequestedName = normalizeName(input.name);
+  const existingExports = await prisma.calendar_subscription.findMany({
+    where: {
+      user_id: input.userId,
+      org_id: input.orgId,
+      ...(input.excludeId ? { id: { not: input.excludeId } } : {}),
+    },
+    select: { name: true },
+  });
+
+  return existingExports.some((calendarExport) => {
+    if (!calendarExport.name) {
+      return false;
+    }
+
+    return normalizeName(calendarExport.name) === normalizedRequestedName;
+  });
+}
+
+export async function listCalendarExports(userId: string) {
+  const calendarExports = await prisma.calendar_subscription.findMany({
+    where: { user_id: userId },
+    include: {
+      organization: {
+        select: {
+          id: true,
+          name: true,
+          helper_name_singular: true,
+          helper_name_plural: true,
+          einsatz_name_singular: true,
+          einsatz_name_plural: true,
+        },
+      },
+    },
+    orderBy: [{ is_active: 'desc' }, { name: 'asc' }],
+  });
+
+  return calendarExports.map((calendarExport) => ({
+    ...calendarExport,
+    parsedConfig: parseCalendarExportConfig(calendarExport.config),
+  }));
+}
+
+export async function createCalendarExport(input: {
+  userId: string;
+  orgId: string;
+  name: string;
+  config: CalendarExportConfig;
+}) {
+  const uniqueName = await createUniqueCalendarExportName({
+    userId: input.userId,
+    orgId: input.orgId,
+    requestedName: input.name,
   });
 
   return prisma.calendar_subscription.create({
     data: {
-      user_id: userId,
-      org_id: orgId,
+      user_id: input.userId,
+      org_id: input.orgId,
       token: generatedToken(24),
-      name: organization?.name,
+      name: uniqueName,
       is_active: true,
+      config: toJsonInput(input.config),
+    },
+  });
+}
+
+export async function updateCalendarExport(input: {
+  id: string;
+  userId: string;
+  name: string;
+  config: CalendarExportConfig;
+}) {
+  const existing = await prisma.calendar_subscription.findFirst({
+    where: { id: input.id, user_id: input.userId },
+    select: { org_id: true },
+  });
+
+  if (!existing) {
+    throw new Error('Kalenderexport wurde nicht gefunden.');
+  }
+
+  const trimmedName = input.name.trim();
+  if (
+    await calendarExportNameExists({
+      userId: input.userId,
+      orgId: existing.org_id,
+      name: trimmedName,
+      excludeId: input.id,
+    })
+  ) {
+    throw new Error('Dieser Name wird bereits verwendet.');
+  }
+
+  return prisma.calendar_subscription.update({
+    where: { id: input.id, user_id: input.userId },
+    data: {
+      name: trimmedName,
+      config: toJsonInput(input.config),
     },
   });
 }
 
 export async function rotateCalendarSubscription(id: string, userId: string) {
   if (!id || !userId) {
-    throw new Error('Organisation oder Benutzer konnte nicht zugeordnet werden.');
+    throw new Error(
+      'Organisation oder Benutzer konnte nicht zugeordnet werden.'
+    );
   }
 
   return prisma.calendar_subscription.update({
@@ -43,28 +189,141 @@ export async function rotateCalendarSubscription(id: string, userId: string) {
   });
 }
 
-export async function deactivateCalendarSubscription(
-  id: string,
-  userId: string
-) {
-  if (!id || !userId) {
-    throw new Error('Organisation oder Benutzer konnte nicht zugeordnet werden.');
-  }
-
+export async function setCalendarExportActive(input: {
+  id: string;
+  userId: string;
+  isActive: boolean;
+}) {
   return prisma.calendar_subscription.update({
-    where: { id, user_id: userId },
-    data: { is_active: false },
+    where: { id: input.id, user_id: input.userId },
+    data: { is_active: input.isActive },
   });
 }
 
-export async function activateCalendarSubscription(id: string, userId: string) {
-  if (!id || !userId) {
-    throw new Error('Organisation oder Benutzer konnte nicht zugeordnet werden.');
+export async function deleteCalendarExport(id: string, userId: string) {
+  return prisma.calendar_subscription.delete({
+    where: { id, user_id: userId },
+  });
+}
+
+export async function listCalendarExportTemplates(orgId: string) {
+  const templates = await prisma.calendar_export_template.findMany({
+    where: { org_id: orgId },
+    orderBy: [{ name: 'asc' }],
+  });
+
+  return templates.map((template) => ({
+    ...template,
+    parsedConfig: parseCalendarExportConfig(template.config),
+  }));
+}
+
+export async function createCalendarExportTemplate(input: {
+  orgId: string;
+  name: string;
+  description?: string | null;
+  config: CalendarExportConfig;
+}) {
+  return prisma.calendar_export_template.create({
+    data: {
+      org_id: input.orgId,
+      name: input.name.trim(),
+      description: input.description?.trim() || null,
+      config: toJsonInput(input.config),
+    },
+  });
+}
+
+export async function updateCalendarExportTemplate(input: {
+  id: string;
+  orgId: string;
+  name: string;
+  description?: string | null;
+  config: CalendarExportConfig;
+}) {
+  return prisma.calendar_export_template.update({
+    where: { id: input.id, org_id: input.orgId },
+    data: {
+      name: input.name.trim(),
+      description: input.description?.trim() || null,
+      config: toJsonInput(input.config),
+      updated_at: new Date(),
+    },
+  });
+}
+
+export async function deleteCalendarExportTemplate(id: string, orgId: string) {
+  return prisma.calendar_export_template.delete({
+    where: { id, org_id: orgId },
+  });
+}
+
+export async function seedDefaultCalendarExportTemplatesForOrg(
+  orgId: string,
+  executor: CalendarTemplateExecutor = prisma
+) {
+  await executor.calendar_export_template.createMany({
+    data: [
+      {
+        org_id: orgId,
+        name: 'Nur offene in der Zukunft',
+        description: null,
+        config: toJsonInput(createOpenFutureTemplateConfig(OPEN_STATUS_ID)),
+      },
+      {
+        org_id: orgId,
+        name: 'Nur eigene in der Zukunft',
+        description: null,
+        config: toJsonInput(createOwnFutureTemplateConfig()),
+      },
+      {
+        org_id: orgId,
+        name: 'Alle Ereignisse',
+        description: null,
+        config: toJsonInput(getBlankCalendarExportConfig('helper')),
+      },
+      {
+        org_id: orgId,
+        name: 'Alle Ereignisse',
+        description: null,
+        config: toJsonInput(getBlankCalendarExportConfig('verwaltung')),
+      },
+    ],
+  });
+}
+
+export async function getOrCreateCalendarSubscription(
+  orgId: string,
+  userId: string,
+  executor: CalendarSubscriptionExecutor = prisma
+) {
+  if (!orgId || !userId) {
+    throw new Error(
+      'Organisation oder Benutzer konnte nicht zugeordnet werden.'
+    );
   }
 
-  return prisma.calendar_subscription.update({
-    where: { id, user_id: userId },
-    data: { is_active: true },
+  const existingCalendarSubscription =
+    await executor.calendar_subscription.findFirst({
+      where: { org_id: orgId, user_id: userId, is_active: true },
+    });
+  if (existingCalendarSubscription) {
+    return existingCalendarSubscription;
+  }
+  const organization = await executor.organization.findUnique({
+    where: { id: orgId },
+    select: { name: true },
+  });
+
+  return executor.calendar_subscription.create({
+    data: {
+      user_id: userId,
+      org_id: orgId,
+      token: generatedToken(24),
+      name: organization?.name,
+      is_active: true,
+      config: toJsonInput(getBlankCalendarExportConfig('helper')),
+    },
   });
 }
 

--- a/src/features/calendar-subscription/config.ts
+++ b/src/features/calendar-subscription/config.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+
+export const calendarExportModes = ['helper', 'verwaltung'] as const;
+export type CalendarExportMode = (typeof calendarExportModes)[number];
+
+export const calendarExportStatusPseudoValues = ['own'] as const;
+export type CalendarExportStatusPseudo =
+  (typeof calendarExportStatusPseudoValues)[number];
+
+export const calendarExportTitleAdditionKeys = [
+  'categories',
+  'helperCount',
+] as const;
+export type CalendarExportTitleAdditionKey =
+  (typeof calendarExportTitleAdditionKeys)[number];
+
+const normalizedTimeSchema = z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/);
+
+export const calendarExportConfigSchema = z
+  .object({
+    version: z.literal(1),
+    mode: z.enum(calendarExportModes),
+    categoryIds: z.array(z.uuid()),
+    statusIds: z.array(z.uuid()),
+    statusPseudo: z.array(z.enum(calendarExportStatusPseudoValues)),
+    timeWindow: z
+      .object({
+        from: normalizedTimeSchema,
+        to: normalizedTimeSchema,
+      })
+      .nullable(),
+    includeAllDay: z.boolean(),
+    futureOnly: z.boolean(),
+    titleAdditions: z.object({
+      categories: z.boolean(),
+      helperCount: z.boolean(),
+    }),
+  })
+  .transform((config) =>
+    config.mode === 'verwaltung'
+      ? {
+          ...config,
+          statusPseudo: config.statusPseudo.filter((value) => value !== 'own'),
+        }
+      : config
+  );
+
+export type CalendarExportConfig = z.infer<typeof calendarExportConfigSchema>;
+
+export const defaultCalendarExportConfig: CalendarExportConfig = {
+  version: 1,
+  mode: 'helper',
+  categoryIds: [],
+  statusIds: [],
+  statusPseudo: [],
+  timeWindow: null,
+  includeAllDay: true,
+  futureOnly: false,
+  titleAdditions: {
+    categories: true,
+    helperCount: true,
+  },
+};
+
+export function parseCalendarExportConfig(
+  value: unknown
+): CalendarExportConfig {
+  const result = calendarExportConfigSchema.safeParse(value);
+  return result.success ? result.data : defaultCalendarExportConfig;
+}
+
+export function getBlankCalendarExportConfig(
+  mode: CalendarExportMode = 'helper'
+): CalendarExportConfig {
+  return {
+    ...defaultCalendarExportConfig,
+    mode,
+    categoryIds: [],
+    statusIds: [],
+    statusPseudo: [],
+    timeWindow: null,
+    titleAdditions: {
+      ...defaultCalendarExportConfig.titleAdditions,
+    },
+  };
+}
+
+export function createOpenFutureTemplateConfig(
+  openStatusId: string
+): CalendarExportConfig {
+  return {
+    ...getBlankCalendarExportConfig('helper'),
+    statusIds: [openStatusId],
+    futureOnly: true,
+  };
+}
+
+export function createOwnFutureTemplateConfig(): CalendarExportConfig {
+  return {
+    ...getBlankCalendarExportConfig('helper'),
+    statusPseudo: ['own'],
+    futureOnly: true,
+  };
+}

--- a/src/features/calendar-subscription/filter.test.ts
+++ b/src/features/calendar-subscription/filter.test.ts
@@ -156,6 +156,23 @@ describe('calendar export filter', () => {
     ).toBe(false);
   });
 
+  it('matches timed events spanning at least 24 hours for any time window overlap', () => {
+    const exportConfig = config({
+      timeWindow: { from: '16:00', to: '20:00' },
+    });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 4, 9, 0),
+          end: new Date(2026, 5, 5, 9, 0),
+        }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(true);
+  });
+
   it('includes all-day events only when configured', () => {
     const allDayEvent = event({ all_day: true });
 
@@ -176,6 +193,16 @@ describe('calendar export filter', () => {
           timeWindow: { from: '16:00', to: '20:00' },
           includeAllDay: false,
         }),
+        'user-1'
+      )
+    ).toBe(false);
+  });
+
+  it('excludes all-day events without a time window when configured', () => {
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ all_day: true }),
+        config({ includeAllDay: false, timeWindow: null }),
         'user-1'
       )
     ).toBe(false);

--- a/src/features/calendar-subscription/filter.test.ts
+++ b/src/features/calendar-subscription/filter.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterCalendarExportEvents,
+  eventMatchesCalendarExportConfig,
+} from './filter';
+import {
+  defaultCalendarExportConfig,
+  type CalendarExportConfig,
+} from './config';
+
+function config(
+  overrides: Partial<CalendarExportConfig>
+): CalendarExportConfig {
+  return {
+    ...defaultCalendarExportConfig,
+    ...overrides,
+    titleAdditions: {
+      ...defaultCalendarExportConfig.titleAdditions,
+      ...overrides.titleAdditions,
+    },
+  };
+}
+
+function event(overrides: {
+  id?: string;
+  start?: Date;
+  end?: Date;
+  all_day?: boolean;
+  status_id?: string;
+  categoryIds?: string[];
+  helperUserIds?: string[];
+}) {
+  return {
+    id: overrides.id ?? 'event-1',
+    start: overrides.start ?? new Date(2026, 5, 4, 16, 0),
+    end: overrides.end ?? new Date(2026, 5, 4, 18, 0),
+    all_day: overrides.all_day ?? false,
+    status_id: overrides.status_id ?? 'status-open',
+    einsatz_to_category: (overrides.categoryIds ?? []).map((categoryId) => ({
+      category_id: categoryId,
+    })),
+    einsatz_helper: (overrides.helperUserIds ?? []).map((userId) => ({
+      user_id: userId,
+    })),
+  };
+}
+
+describe('calendar export filter', () => {
+  it('treats selected categories as OR and empty categories as no filter', () => {
+    const exportConfig = config({ categoryIds: ['cat-a', 'cat-b'] });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ categoryIds: ['cat-b'] }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ categoryIds: ['cat-c'] }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(false);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ categoryIds: [] }),
+        config({ categoryIds: [] }),
+        'user-1'
+      )
+    ).toBe(true);
+  });
+
+  it('matches real statuses and eigene as OR branches', () => {
+    const exportConfig = config({
+      mode: 'helper',
+      statusIds: ['status-open'],
+      statusPseudo: ['own'],
+    });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ status_id: 'status-open' }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ status_id: 'status-assigned', helperUserIds: ['user-1'] }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({ status_id: 'status-assigned', helperUserIds: ['user-2'] }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(false);
+  });
+
+  it('matches timed events that overlap a same-day time window', () => {
+    const exportConfig = config({
+      timeWindow: { from: '16:00', to: '20:00' },
+    });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 4, 15, 0),
+          end: new Date(2026, 5, 4, 17, 0),
+        }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 4, 14, 0),
+          end: new Date(2026, 5, 4, 15, 0),
+        }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(false);
+  });
+
+  it('matches overnight time windows', () => {
+    const exportConfig = config({
+      timeWindow: { from: '22:00', to: '02:00' },
+    });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 4, 23, 0),
+          end: new Date(2026, 5, 4, 23, 30),
+        }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 4, 12, 0),
+          end: new Date(2026, 5, 4, 13, 0),
+        }),
+        exportConfig,
+        'user-1'
+      )
+    ).toBe(false);
+  });
+
+  it('includes all-day events only when configured', () => {
+    const allDayEvent = event({ all_day: true });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        allDayEvent,
+        config({
+          timeWindow: { from: '16:00', to: '20:00' },
+          includeAllDay: true,
+        }),
+        'user-1'
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        allDayEvent,
+        config({
+          timeWindow: { from: '16:00', to: '20:00' },
+          includeAllDay: false,
+        }),
+        'user-1'
+      )
+    ).toBe(false);
+  });
+
+  it('uses event end for future-only filtering', () => {
+    const now = new Date(2026, 5, 4, 10, 0);
+    const exportConfig = config({ futureOnly: true });
+
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 3, 20, 0),
+          end: new Date(2026, 5, 4, 1, 0),
+        }),
+        exportConfig,
+        'user-1',
+        now
+      )
+    ).toBe(true);
+    expect(
+      eventMatchesCalendarExportConfig(
+        event({
+          start: new Date(2026, 5, 2, 20, 0),
+          end: new Date(2026, 5, 3, 23, 0),
+        }),
+        exportConfig,
+        'user-1',
+        now
+      )
+    ).toBe(false);
+  });
+
+  it('trims old past events only when there are more than 500 matches', () => {
+    const now = new Date(2026, 5, 4, 12, 0);
+    const oldEvents = Array.from({ length: 300 }, (_, index) =>
+      event({
+        id: `old-${index}`,
+        start: new Date(2026, 3, 1, 10, 0),
+        end: new Date(2026, 3, 1, 11, 0),
+      })
+    );
+    const recentEvents = Array.from({ length: 250 }, (_, index) =>
+      event({
+        id: `recent-${index}`,
+        start: new Date(2026, 4, 20, 10, 0),
+        end: new Date(2026, 4, 20, 11, 0),
+      })
+    );
+
+    const result = filterCalendarExportEvents(
+      [...oldEvents, ...recentEvents],
+      defaultCalendarExportConfig,
+      'user-1',
+      now
+    );
+
+    expect(result.events).toHaveLength(250);
+    expect(result.trimmedBefore).toEqual(new Date(2026, 4, 4));
+  });
+});

--- a/src/features/calendar-subscription/filter.ts
+++ b/src/features/calendar-subscription/filter.ts
@@ -59,12 +59,17 @@ function eventOverlapsTimeWindow(
   event: CalendarExportFilterEvent,
   config: CalendarExportConfig
 ) {
+  if (event.all_day) {
+    return config.includeAllDay;
+  }
+
   if (!config.timeWindow) {
     return true;
   }
 
-  if (event.all_day) {
-    return config.includeAllDay;
+  const durationMs = event.end.getTime() - event.start.getTime();
+  if (durationMs >= 24 * 60 * 60 * 1000) {
+    return true;
   }
 
   const eventStart = event.start.getHours() * 60 + event.start.getMinutes();

--- a/src/features/calendar-subscription/filter.ts
+++ b/src/features/calendar-subscription/filter.ts
@@ -1,0 +1,194 @@
+import { startOfDay, subMonths } from 'date-fns';
+import type { CalendarExportConfig } from './config';
+
+export type CalendarExportFilterEvent = {
+  id: string;
+  start: Date;
+  end: Date;
+  all_day: boolean;
+  status_id: string;
+  einsatz_to_category: Array<{
+    category_id?: string;
+    einsatz_category?: {
+      id?: string;
+    };
+  }>;
+  einsatz_helper: Array<{
+    user_id?: string;
+    user?: {
+      id?: string;
+    };
+  }>;
+};
+
+export type CalendarExportSizeGuardResult<T> = {
+  events: T[];
+  trimmedBefore: Date | null;
+};
+
+function parseTimeToMinutes(value: string): number {
+  const [hours = '0', minutes = '0'] = value.split(':');
+  return Number(hours) * 60 + Number(minutes);
+}
+
+function getDailySegments(from: number, to: number): Array<[number, number]> {
+  if (from === to) {
+    return [[0, 1440]];
+  }
+
+  if (from < to) {
+    return [[from, to]];
+  }
+
+  return [
+    [from, 1440],
+    [0, to],
+  ];
+}
+
+function rangesOverlap(
+  leftStart: number,
+  leftEnd: number,
+  rightStart: number,
+  rightEnd: number
+) {
+  return leftStart < rightEnd && rightStart < leftEnd;
+}
+
+function eventOverlapsTimeWindow(
+  event: CalendarExportFilterEvent,
+  config: CalendarExportConfig
+) {
+  if (!config.timeWindow) {
+    return true;
+  }
+
+  if (event.all_day) {
+    return config.includeAllDay;
+  }
+
+  const eventStart = event.start.getHours() * 60 + event.start.getMinutes();
+  const rawEventEnd = event.end.getHours() * 60 + event.end.getMinutes();
+  const eventEnd = rawEventEnd === eventStart ? eventStart + 1 : rawEventEnd;
+  const eventSegments =
+    eventStart < eventEnd
+      ? ([[eventStart, eventEnd]] satisfies Array<[number, number]>)
+      : ([
+          [eventStart, 1440],
+          [0, eventEnd],
+        ] satisfies Array<[number, number]>);
+
+  const filterSegments = getDailySegments(
+    parseTimeToMinutes(config.timeWindow.from),
+    parseTimeToMinutes(config.timeWindow.to)
+  );
+
+  return eventSegments.some(([eventSegmentStart, eventSegmentEnd]) =>
+    filterSegments.some(([filterSegmentStart, filterSegmentEnd]) =>
+      rangesOverlap(
+        eventSegmentStart,
+        eventSegmentEnd,
+        filterSegmentStart,
+        filterSegmentEnd
+      )
+    )
+  );
+}
+
+function eventMatchesCategories(
+  event: CalendarExportFilterEvent,
+  config: CalendarExportConfig
+) {
+  if (config.categoryIds.length === 0) {
+    return true;
+  }
+
+  const selectedCategoryIds = new Set(config.categoryIds);
+  return event.einsatz_to_category.some((category) => {
+    const categoryId = category.category_id ?? category.einsatz_category?.id;
+    return categoryId ? selectedCategoryIds.has(categoryId) : false;
+  });
+}
+
+function eventMatchesStatus(
+  event: CalendarExportFilterEvent,
+  config: CalendarExportConfig,
+  ownerUserId: string
+) {
+  if (config.statusIds.length === 0 && config.statusPseudo.length === 0) {
+    return true;
+  }
+
+  if (config.statusIds.includes(event.status_id)) {
+    return true;
+  }
+
+  if (config.mode === 'helper' && config.statusPseudo.includes('own')) {
+    return event.einsatz_helper.some((helper) => {
+      const helperUserId = helper.user_id ?? helper.user?.id;
+      return helperUserId === ownerUserId;
+    });
+  }
+
+  return false;
+}
+
+function eventMatchesFutureOnly(
+  event: CalendarExportFilterEvent,
+  config: CalendarExportConfig,
+  now: Date
+) {
+  if (!config.futureOnly) {
+    return true;
+  }
+
+  return event.end >= startOfDay(now);
+}
+
+export function eventMatchesCalendarExportConfig(
+  event: CalendarExportFilterEvent,
+  config: CalendarExportConfig,
+  ownerUserId: string,
+  now: Date = new Date()
+) {
+  return (
+    eventMatchesCategories(event, config) &&
+    eventMatchesStatus(event, config, ownerUserId) &&
+    eventOverlapsTimeWindow(event, config) &&
+    eventMatchesFutureOnly(event, config, now)
+  );
+}
+
+export function applyCalendarExportSizeGuard<T extends { end: Date }>(
+  events: T[],
+  now: Date = new Date()
+): CalendarExportSizeGuardResult<T> {
+  if (events.length <= 500) {
+    return { events, trimmedBefore: null };
+  }
+
+  const minimumPastDate = startOfDay(subMonths(now, 1));
+  const guardedEvents = events.filter((event) => event.end >= minimumPastDate);
+
+  if (guardedEvents.length === events.length) {
+    return { events, trimmedBefore: null };
+  }
+
+  return {
+    events: guardedEvents,
+    trimmedBefore: minimumPastDate,
+  };
+}
+
+export function filterCalendarExportEvents<T extends CalendarExportFilterEvent>(
+  events: T[],
+  config: CalendarExportConfig,
+  ownerUserId: string,
+  now: Date = new Date()
+): CalendarExportSizeGuardResult<T> {
+  const matchingEvents = events.filter((event) =>
+    eventMatchesCalendarExportConfig(event, config, ownerUserId, now)
+  );
+
+  return applyCalendarExportSizeGuard(matchingEvents, now);
+}

--- a/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
+++ b/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
@@ -1,56 +1,110 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
 import {
-  getSubscriptionAction,
+  createCalendarExportAction,
+  createCalendarExportTemplateAction,
+  deleteCalendarExportAction,
+  deleteCalendarExportTemplateAction,
+  getCalendarExportPreviewAction,
+  listCalendarExportEligibilityAction,
+  listCalendarExportsAction,
+  listCalendarExportTemplatesAction,
+  listCompatibleCalendarExportTemplatesAction,
   rotateSubscriptionAction,
-  deactivateSubscriptionAction,
-  activateSubscriptionAction,
+  setCalendarExportActiveAction,
+  updateCalendarExportAction,
+  updateCalendarExportTemplateAction,
 } from '../actions';
-import { useSession } from 'next-auth/react';
-import { settingsQueryKeys } from '@/features/settings/queryKeys/queryKey';
+import type { CalendarExportConfig } from '../config';
+import { calendarSubscriptionQueryKeys } from '../queryKeys';
 
-export type CalendarSubscription = {
-  id: string;
+export type CalendarExport = Awaited<
+  ReturnType<typeof listCalendarExportsAction>
+>[number];
+
+export type CalendarExportTemplate = Awaited<
+  ReturnType<typeof listCalendarExportTemplatesAction>
+>[number];
+
+export type CalendarExportEligibility = Awaited<
+  ReturnType<typeof listCalendarExportEligibilityAction>
+>[number];
+
+export type CalendarExportMutationInput = {
+  orgId: string;
   name: string;
-  is_active: boolean;
-  token: string;
-  webcalUrl: string;
-  httpUrl: string;
-  last_accessed: string | null;
+  config: CalendarExportConfig;
 };
 
-const key = (userId?: string, orgId?: string) =>
-  settingsQueryKeys.calendarSubscription(userId, orgId);
+export type CalendarExportTemplateMutationInput = {
+  orgId: string;
+  id?: string;
+  name: string;
+  description?: string | null;
+  config: CalendarExportConfig;
+};
 
-export function useCalendarSubscription(orgId: string) {
+export function useCalendarExports() {
   const queryClient = useQueryClient();
   const session = useSession();
   const userId = session.data?.user?.id;
-  const queryKey = key(userId, orgId);
+  const queryKey = calendarSubscriptionQueryKeys.exports(userId);
 
   const query = useQuery({
     queryKey,
-    queryFn: () => getSubscriptionAction(orgId),
-    enabled: !!orgId && !!userId,
+    queryFn: () => listCalendarExportsAction(),
+    enabled: !!userId,
     staleTime: 60000,
-    retry: 3,
+  });
+
+  const invalidateExports = () =>
+    queryClient.invalidateQueries({
+      queryKey: calendarSubscriptionQueryKeys.exports(userId),
+    });
+
+  const createExport = useMutation({
+    mutationFn: ({ orgId, name, config }: CalendarExportMutationInput) =>
+      createCalendarExportAction(orgId, { name, config }),
+    onSuccess: async () => {
+      await invalidateExports();
+      toast.success('Kalenderexport wurde erstellt');
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Kalenderexport konnte nicht erstellt werden'
+      );
+    },
+  });
+
+  const updateExport = useMutation({
+    mutationFn: ({
+      id,
+      name,
+      config,
+    }: CalendarExportMutationInput & { id: string }) =>
+      updateCalendarExportAction(id, { name, config }),
+    onSuccess: async () => {
+      await invalidateExports();
+      toast.success('Kalenderexport wurde gespeichert');
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Kalenderexport konnte nicht gespeichert werden'
+      );
+    },
   });
 
   const rotate = useMutation({
     mutationFn: (id: string) => rotateSubscriptionAction(id),
-    onSuccess: (data) => {
-      queryClient.setQueryData<CalendarSubscription>(queryKey, (prev) =>
-        prev
-          ? {
-              ...prev,
-              token: data.token,
-              webcalUrl: data.webcalUrl,
-              httpUrl: data.httpUrl,
-            }
-          : prev
-      );
+    onSuccess: async () => {
+      await invalidateExports();
       toast.success('Neuer Kalender-Link wurde generiert');
     },
     onError: (error) => {
@@ -61,39 +115,167 @@ export function useCalendarSubscription(orgId: string) {
       );
     },
   });
-  const deactivate = useMutation({
-    mutationFn: (id: string) => deactivateSubscriptionAction(id),
-    onSuccess: () => {
-      queryClient.setQueryData<CalendarSubscription>(queryKey, (prev) =>
-        prev ? { ...prev, is_active: false } : prev
+
+  const setActive = useMutation({
+    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) =>
+      setCalendarExportActiveAction(id, isActive),
+    onSuccess: async (_, variables) => {
+      await invalidateExports();
+      toast.success(
+        variables.isActive
+          ? 'Kalenderexport wurde aktiviert'
+          : 'Kalenderexport wurde deaktiviert'
       );
-      toast.success('Kalender-Integration wurde deaktiviert');
     },
     onError: (error) => {
       toast.error(
         error instanceof Error
           ? error.message
-          : 'Fehler beim Deaktivieren der Kalender-Integration'
+          : 'Kalenderexport konnte nicht geändert werden'
       );
     },
   });
 
-  const activate = useMutation({
-    mutationFn: (id: string) => activateSubscriptionAction(id),
-    onSuccess: () => {
-      queryClient.setQueryData<CalendarSubscription>(queryKey, (prev) =>
-        prev ? { ...prev, is_active: true } : prev
-      );
-      toast.success('Kalender-Integration wurde aktiviert');
+  const remove = useMutation({
+    mutationFn: (id: string) => deleteCalendarExportAction(id),
+    onSuccess: async () => {
+      await invalidateExports();
+      toast.success('Kalenderexport wurde gelöscht');
     },
     onError: (error) => {
       toast.error(
         error instanceof Error
           ? error.message
-          : 'Fehler beim Aktivieren der Kalender-Integration'
+          : 'Kalenderexport konnte nicht gelöscht werden'
       );
     },
   });
 
-  return { query, rotate, deactivate, activate };
+  return {
+    query,
+    createExport,
+    updateExport,
+    rotate,
+    setActive,
+    remove,
+  };
+}
+
+export function useCalendarExportEligibility() {
+  const session = useSession();
+  return useQuery({
+    queryKey: [
+      ...calendarSubscriptionQueryKeys.all,
+      'eligibility',
+      session.data?.user?.id ?? '',
+    ] as const,
+    queryFn: () => listCalendarExportEligibilityAction(),
+    enabled: !!session.data?.user?.id,
+  });
+}
+
+export function useCalendarExportTemplates(orgId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const normalizedOrgId = orgId ?? undefined;
+  const query = useQuery({
+    queryKey: calendarSubscriptionQueryKeys.templates(normalizedOrgId),
+    queryFn: () => listCalendarExportTemplatesAction(orgId ?? ''),
+    enabled: !!orgId,
+  });
+
+  const invalidateTemplates = () =>
+    queryClient.invalidateQueries({
+      queryKey: calendarSubscriptionQueryKeys.templates(normalizedOrgId),
+    });
+
+  const createTemplate = useMutation({
+    mutationFn: ({
+      orgId: mutationOrgId,
+      name,
+      description,
+      config,
+    }: CalendarExportTemplateMutationInput) =>
+      createCalendarExportTemplateAction(mutationOrgId, {
+        name,
+        description,
+        config,
+      }),
+    onSuccess: async () => {
+      await invalidateTemplates();
+      toast.success('Kalenderexport-Vorlage wurde erstellt');
+    },
+  });
+
+  const updateTemplate = useMutation({
+    mutationFn: ({
+      orgId: mutationOrgId,
+      id,
+      name,
+      description,
+      config,
+    }: CalendarExportTemplateMutationInput) => {
+      if (!id) {
+        throw new Error('Vorlage wurde nicht gefunden.');
+      }
+      return updateCalendarExportTemplateAction(mutationOrgId, id, {
+        name,
+        description,
+        config,
+      });
+    },
+    onSuccess: async () => {
+      await invalidateTemplates();
+      toast.success('Kalenderexport-Vorlage wurde gespeichert');
+    },
+  });
+
+  const removeTemplate = useMutation({
+    mutationFn: ({ orgId: mutationOrgId, id }: { orgId: string; id: string }) =>
+      deleteCalendarExportTemplateAction(mutationOrgId, id),
+    onSuccess: async () => {
+      await invalidateTemplates();
+      toast.success('Kalenderexport-Vorlage wurde gelöscht');
+    },
+  });
+
+  return {
+    query,
+    createTemplate,
+    updateTemplate,
+    removeTemplate,
+  };
+}
+
+export function useCompatibleCalendarExportTemplates(
+  orgId: string | null | undefined
+) {
+  const normalizedOrgId = orgId ?? undefined;
+  return useQuery({
+    queryKey: [
+      ...calendarSubscriptionQueryKeys.templates(normalizedOrgId),
+      'compatible',
+    ] as const,
+    queryFn: () => listCompatibleCalendarExportTemplatesAction(orgId ?? ''),
+    enabled: !!orgId,
+  });
+}
+
+export function useCalendarExportPreview(
+  orgId: string | null | undefined,
+  config: CalendarExportConfig | null | undefined
+) {
+  const session = useSession();
+  const normalizedOrgId = orgId ?? undefined;
+  return useQuery({
+    queryKey: [
+      ...calendarSubscriptionQueryKeys.preview(
+        session.data?.user?.id,
+        normalizedOrgId
+      ),
+      config,
+    ] as const,
+    queryFn: () => getCalendarExportPreviewAction(orgId ?? '', config),
+    enabled: !!orgId && !!config && !!session.data?.user?.id,
+    staleTime: 15000,
+  });
 }

--- a/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
+++ b/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
@@ -204,6 +204,9 @@ export function useCalendarExportTemplates(orgId: string | null | undefined) {
       await invalidateTemplates();
       toast.success('Kalenderexport-Vorlage wurde erstellt');
     },
+    onError: () => {
+      toast.error('Kalenderexport-Vorlage konnte nicht erstellt werden');
+    },
   });
 
   const updateTemplate = useMutation({
@@ -227,6 +230,9 @@ export function useCalendarExportTemplates(orgId: string | null | undefined) {
       await invalidateTemplates();
       toast.success('Kalenderexport-Vorlage wurde gespeichert');
     },
+    onError: () => {
+      toast.error('Kalenderexport-Vorlage konnte nicht gespeichert werden');
+    },
   });
 
   const removeTemplate = useMutation({
@@ -235,6 +241,9 @@ export function useCalendarExportTemplates(orgId: string | null | undefined) {
     onSuccess: async () => {
       await invalidateTemplates();
       toast.success('Kalenderexport-Vorlage wurde gelöscht');
+    },
+    onError: () => {
+      toast.error('Kalenderexport-Vorlage konnte nicht gelöscht werden');
     },
   });
 

--- a/src/features/calendar-subscription/queryKeys.ts
+++ b/src/features/calendar-subscription/queryKeys.ts
@@ -1,0 +1,20 @@
+export const calendarSubscriptionQueryKeys = {
+  all: ['calendar-subscription'] as const,
+  exports: (userId?: string) =>
+    [...calendarSubscriptionQueryKeys.all, 'exports', userId ?? ''] as const,
+  exportsByOrg: (userId?: string, orgId?: string) =>
+    [
+      ...calendarSubscriptionQueryKeys.exports(userId),
+      'org',
+      orgId ?? '',
+    ] as const,
+  templates: (orgId?: string) =>
+    [...calendarSubscriptionQueryKeys.all, 'templates', orgId ?? ''] as const,
+  preview: (userId?: string, orgId?: string) =>
+    [
+      ...calendarSubscriptionQueryKeys.all,
+      'preview',
+      userId ?? '',
+      orgId ?? '',
+    ] as const,
+};

--- a/src/features/calendar-subscription/title.test.ts
+++ b/src/features/calendar-subscription/title.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { defaultCalendarExportConfig } from './config';
+import { composeCalendarExportEventTitle } from './title';
+
+describe('composeCalendarExportEventTitle', () => {
+  it('joins categories and helper count in one bracket group', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Führung',
+        categoryAbbreviations: ['DA', 'VA'],
+        assignedHelpers: 1,
+        helpersNeeded: 2,
+        config: defaultCalendarExportConfig,
+      })
+    ).toBe('Führung (DA, VA · 1/2)');
+  });
+
+  it('omits helper count when no helpers are needed', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Führung',
+        categoryAbbreviations: ['DA'],
+        assignedHelpers: 0,
+        helpersNeeded: 0,
+        config: defaultCalendarExportConfig,
+      })
+    ).toBe('Führung (DA)');
+  });
+
+  it('returns only the title when additions are disabled', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Führung',
+        categoryAbbreviations: ['DA'],
+        assignedHelpers: 1,
+        helpersNeeded: 2,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            categories: false,
+            helperCount: false,
+          },
+        },
+      })
+    ).toBe('Führung');
+  });
+});

--- a/src/features/calendar-subscription/title.ts
+++ b/src/features/calendar-subscription/title.ts
@@ -1,0 +1,44 @@
+import type { CalendarExportConfig } from './config';
+
+export function composeCalendarExportEventTitle(input: {
+  title: string;
+  categoryAbbreviations: string[];
+  assignedHelpers: number;
+  helpersNeeded: number;
+  config: CalendarExportConfig;
+}) {
+  const additions: string[] = [];
+
+  if (input.config.titleAdditions.categories) {
+    const categoryText = input.categoryAbbreviations
+      .map((category) => category.trim())
+      .filter(Boolean)
+      .join(', ');
+
+    if (categoryText) {
+      additions.push(categoryText);
+    }
+  }
+
+  if (input.config.titleAdditions.helperCount && input.helpersNeeded > 0) {
+    additions.push(`${input.assignedHelpers}/${input.helpersNeeded}`);
+  }
+
+  return additions.length > 0
+    ? `${input.title} (${additions.join(' · ')})`
+    : input.title;
+}
+
+export function slugifyCalendarExportFilenamePart(value: string) {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/ä/g, 'ae')
+    .replace(/ö/g, 'oe')
+    .replace(/ü/g, 'ue')
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug || 'kalender';
+}

--- a/src/features/invitations/hooks/useInvitationMutations.test.tsx
+++ b/src/features/invitations/hooks/useInvitationMutations.test.tsx
@@ -60,9 +60,13 @@ function createWrapper() {
     },
   });
 
-  return ({ children }: PropsWithChildren) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  return Wrapper;
 }
 
 describe('useAcceptInvitation', () => {

--- a/src/features/settings/settings-action.ts
+++ b/src/features/settings/settings-action.ts
@@ -510,12 +510,20 @@ export async function removeUserFromOrganizationAction(
       };
     }
 
-    await prisma.user_organization_role.deleteMany({
-      where: {
-        user_id: userId,
-        org_id: organizationId,
-      },
-    });
+    await prisma.$transaction([
+      prisma.calendar_subscription.deleteMany({
+        where: {
+          user_id: userId,
+          org_id: organizationId,
+        },
+      }),
+      prisma.user_organization_role.deleteMany({
+        where: {
+          user_id: userId,
+          org_id: organizationId,
+        },
+      }),
+    ]);
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: { active_org: true },

--- a/src/features/settings/users-action.ts
+++ b/src/features/settings/users-action.ts
@@ -221,12 +221,20 @@ export async function removeUserFromOrganizationAction(
     throw new Error('Keine Berechtigung zum Entfernen von Benutzern.');
   }
 
-  await prisma.user_organization_role.deleteMany({
-    where: {
-      user_id: userId,
-      org_id: organizationId,
-    },
-  });
+  await prisma.$transaction([
+    prisma.calendar_subscription.deleteMany({
+      where: {
+        user_id: userId,
+        org_id: organizationId,
+      },
+    }),
+    prisma.user_organization_role.deleteMany({
+      where: {
+        user_id: userId,
+        org_id: organizationId,
+      },
+    }),
+  ]);
 
   revalidatePath(`/organization/${organizationId}`);
 

--- a/src/hooks/use-multi-step-viewer.tsx
+++ b/src/hooks/use-multi-step-viewer.tsx
@@ -22,7 +22,7 @@ export interface UseMultiFormStepsReturn {
 }
 
 // Context type
-interface MultiStepFormContextType extends UseMultiFormStepsReturn {}
+type MultiStepFormContextType = UseMultiFormStepsReturn
 
 // Create context
 const MultiStepFormContext = createContext<MultiStepFormContextType | null>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added organization-level **Kalenderexport-Vorlagen** management to org settings, including create/edit/delete and template-based export configuration.
  * Improved calendar exports with a guided wizard (**Allgemein → Filter → Vorschau**), including category/status filtering, time-window options, and helper/administration modes.
  * Added an export **preview** before saving, plus better generated titles, descriptions, and downloadable calendar filenames.

* **UI Updates**
  * Refreshed calendar export wording and layout in settings (including responsive organization cards and updated section separation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->