### PR TITLE
[codex] Fix calendar export organization updates

### DIFF
--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -335,9 +335,8 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
 
   const save = async (values: FormValues) => {
     if (props.mode === 'personal' && props.onSavePersonal) {
-      let result: SavedExport | void;
       try {
-        result = await props.onSavePersonal({
+        await props.onSavePersonal({
           id: props.exportToEdit?.id,
           orgId: values.orgId,
           name: values.name,
@@ -346,10 +345,8 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
       } catch {
         return;
       }
-      if (result) {
-        setSavedExport(result);
-      }
       form.reset(values);
+      props.onOpenChange(false);
       return;
     }
 

--- a/src/components/settings/userProfile/CalendarIntegrationCard.tsx
+++ b/src/components/settings/userProfile/CalendarIntegrationCard.tsx
@@ -439,7 +439,7 @@ export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
         exportToEdit={editExport}
         onOpenChange={setDialogOpen}
         onSavePersonal={async (input) => {
-          if (input.id && input.orgId === editExport?.orgId) {
+          if (input.id) {
             const result = await calendarExports.updateExport.mutateAsync({
               id: input.id,
               orgId: input.orgId,

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -35,6 +35,10 @@ const exportInputSchema = z.object({
   config: calendarExportConfigSchema,
 });
 
+const exportUpdateInputSchema = exportInputSchema.extend({
+  orgId: z.string().uuid('Die Organisation ist ungültig.'),
+});
+
 const templateInputSchema = exportInputSchema.extend({
   description: z.string().trim().optional().nullable(),
 });
@@ -293,7 +297,7 @@ export async function createCalendarExportAction(
 
 export async function updateCalendarExportAction(
   id: string,
-  input: z.input<typeof exportInputSchema>
+  input: z.input<typeof exportUpdateInputSchema>
 ) {
   const session = await checkUserSession();
   const existing = await prisma.calendar_subscription.findFirst({
@@ -306,13 +310,15 @@ export async function updateCalendarExportAction(
   }
 
   await assertReadAccess(existing.org_id);
-  const parsedInput = exportInputSchema.parse(input);
-  await assertModeAccess(existing.org_id, parsedInput.config.mode);
-  await validateConfigReferences(existing.org_id, parsedInput.config);
+  const parsedInput = exportUpdateInputSchema.parse(input);
+  await assertReadAccess(parsedInput.orgId);
+  await assertModeAccess(parsedInput.orgId, parsedInput.config.mode);
+  await validateConfigReferences(parsedInput.orgId, parsedInput.config);
 
   const calendarExport = await updateCalendarExport({
     id,
     userId: session.user.id,
+    orgId: parsedInput.orgId,
     name: parsedInput.name,
     config: parsedInput.config,
   });

--- a/src/features/calendar-subscription/calendarSubscription.test.ts
+++ b/src/features/calendar-subscription/calendarSubscription.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultCalendarExportConfig } from './config';
+
+const { mockFindFirst, mockFindMany, mockUpdate } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    calendar_subscription: {
+      findFirst: mockFindFirst,
+      findMany: mockFindMany,
+      update: mockUpdate,
+    },
+  },
+}));
+
+import { updateCalendarExport } from './calendarSubscription';
+
+describe('calendar subscription dal', () => {
+  beforeEach(() => {
+    mockFindFirst.mockReset();
+    mockFindMany.mockReset();
+    mockUpdate.mockReset();
+  });
+
+  it('verschiebt einen bestehenden Kalenderexport beim Bearbeiten in die neue Organisation', async () => {
+    mockFindFirst.mockResolvedValue({ org_id: 'old-org' });
+    mockFindMany.mockResolvedValue([]);
+    mockUpdate.mockResolvedValue({
+      id: 'export-1',
+      user_id: 'user-1',
+      org_id: 'new-org',
+      name: 'Mein Export',
+      config: defaultCalendarExportConfig,
+    });
+
+    await updateCalendarExport({
+      id: 'export-1',
+      userId: 'user-1',
+      orgId: 'new-org',
+      name: ' Mein Export ',
+      config: defaultCalendarExportConfig,
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        user_id: 'user-1',
+        org_id: 'new-org',
+        id: { not: 'export-1' },
+      },
+      select: { name: true },
+    });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'export-1', user_id: 'user-1' },
+      data: {
+        org_id: 'new-org',
+        name: 'Mein Export',
+        config: defaultCalendarExportConfig,
+      },
+    });
+  });
+});

--- a/src/features/calendar-subscription/calendarSubscription.ts
+++ b/src/features/calendar-subscription/calendarSubscription.ts
@@ -140,6 +140,7 @@ export async function createCalendarExport(input: {
 export async function updateCalendarExport(input: {
   id: string;
   userId: string;
+  orgId: string;
   name: string;
   config: CalendarExportConfig;
 }) {
@@ -156,7 +157,7 @@ export async function updateCalendarExport(input: {
   if (
     await calendarExportNameExists({
       userId: input.userId,
-      orgId: existing.org_id,
+      orgId: input.orgId,
       name: trimmedName,
       excludeId: input.id,
     })
@@ -167,6 +168,7 @@ export async function updateCalendarExport(input: {
   return prisma.calendar_subscription.update({
     where: { id: input.id, user_id: input.userId },
     data: {
+      org_id: input.orgId,
       name: trimmedName,
       config: toJsonInput(input.config),
     },

--- a/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
+++ b/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
@@ -84,10 +84,11 @@ export function useCalendarExports() {
   const updateExport = useMutation({
     mutationFn: ({
       id,
+      orgId,
       name,
       config,
     }: CalendarExportMutationInput & { id: string }) =>
-      updateCalendarExportAction(id, { name, config }),
+      updateCalendarExportAction(id, { orgId, name, config }),
     onSuccess: async () => {
       await invalidateExports();
       toast.success('Kalenderexport wurde gespeichert');


### PR DESCRIPTION
## Summary

- update existing Kalenderexporte when the selected organisation changes instead of creating a second export
- validate update permissions and config references against the target organisation
- close the Kalenderexport dialog automatically after a successful save
- add regression coverage for moving an existing export to another organisation

## Root Cause

The edit flow only called the update mutation when the submitted organisation matched the export's original organisation. Changing the organisation fell through to the create mutation, leaving the old export and adding a new one.

## Validation

- `pnpm test:run`
- `pnpm tsc`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar export updates to correctly handle organization reassignment when moving exports between organizations.
  * Streamlined the export save workflow to close the dialog immediately after a successful save.

* **Tests**
  * Added test coverage for calendar export update operations, including cross-organization reassignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->