### PR TITLE
Codex/calendar title parts

### DIFF
--- a/src/app/api/calendar/[token]/route.test.ts
+++ b/src/app/api/calendar/[token]/route.test.ts
@@ -167,4 +167,94 @@ describe('GET /api/calendar/[token]', () => {
       })
     );
   });
+
+  it('exportiert eingeteilte Personen und offene Plätze im Summary', async () => {
+    mockFindSubscription.mockResolvedValue({
+      user_id: 'user-1',
+      org_id: 'orga-1',
+      name: 'Café Export',
+      is_active: true,
+      config: {
+        version: 1,
+        mode: 'helper',
+        categoryIds: [],
+        statusIds: [],
+        statusPseudo: [],
+        timeWindow: null,
+        includeAllDay: true,
+        futureOnly: false,
+        titleAdditions: {
+          eventTitle: true,
+          assignedHelperNames: true,
+          categories: false,
+          helperCount: true,
+        },
+      },
+      organization: {
+        name: 'Organisation',
+        email: null,
+        phone: null,
+        helper_name_plural: 'Helfer:innen',
+        einsatz_name_singular: 'Einsatz',
+      },
+    });
+    mockFindEinsaetze.mockResolvedValue([
+      {
+        id: 'einsatz-1',
+        title: 'Kassa/Café',
+        start: new Date('2026-06-18T10:00:00.000Z'),
+        end: new Date('2026-06-18T11:00:00.000Z'),
+        all_day: false,
+        anmerkung: null,
+        helpers_needed: 2,
+        participant_count: null,
+        price_per_person: null,
+        total_price: null,
+        einsatz_to_category: [],
+        einsatz_field: [],
+        einsatz_user_property: [],
+        einsatz_helper: [
+          {
+            user_id: 'user-1',
+            user: {
+              id: 'user-1',
+              firstname: 'Raphael',
+              lastname: 'Muster',
+            },
+          },
+        ],
+        status_id: 'status-1',
+        einsatz_status: {
+          id: 'status-1',
+          helper_text: 'teilweise vergeben',
+          verwalter_text: 'teilweise vergeben',
+        },
+        organization: {
+          name: 'Organisation',
+        },
+      },
+    ]);
+
+    await GET(
+      new NextRequest('https://einsatzplaner.example/api/calendar/token'),
+      {
+        params: Promise.resolve({ token: 'token' }),
+      }
+    );
+
+    expect(mockFindEinsaetze).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          einsatz_helper: expect.objectContaining({
+            orderBy: { joined_at: 'asc' },
+          }),
+        }),
+      })
+    );
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'Raphael + 1 | Kassa/Café (1/2)',
+      })
+    );
+  });
 });

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -155,6 +155,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
         },
       },
       einsatz_helper: {
+        orderBy: {
+          joined_at: 'asc',
+        },
         include: {
           user: {
             select: {
@@ -378,6 +381,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
       summary: composeCalendarExportEventTitle({
         title: einsatz.title,
         categoryAbbreviations,
+        assignedHelperFirstNames: einsatz.einsatz_helper.map(
+          (helper) => helper.user.firstname
+        ),
         assignedHelpers: einsatz.einsatz_helper.length,
         helpersNeeded: einsatz.helpers_needed,
         config: exportConfig,

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -381,9 +381,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
       summary: composeCalendarExportEventTitle({
         title: einsatz.title,
         categoryAbbreviations,
-        assignedHelperFirstNames: einsatz.einsatz_helper.map(
-          (helper) => helper.user.firstname
-        ),
+        assignedHelperNames: einsatz.einsatz_helper.map((helper) => ({
+          firstname: helper.user.firstname,
+          lastname: helper.user.lastname,
+        })),
         assignedHelpers: einsatz.einsatz_helper.length,
         helpersNeeded: einsatz.helpers_needed,
         config: exportConfig,

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -44,7 +44,10 @@ import {
   type CalendarExportEligibility,
 } from '@/features/calendar-subscription/hooks/useCalendarSubscription';
 import { cn } from '@/lib/utils';
-import { getPreviewDurationTag } from './CalendarExportDialog.utils';
+import {
+  getCalendarExportNameAfterOrgChange,
+  getPreviewDurationTag,
+} from './CalendarExportDialog.utils';
 
 const formSchema = z.object({
   orgId: z.string().uuid(),
@@ -425,7 +428,14 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
       { shouldDirty: true }
     );
     setTimeWindowDraft({ from: '', to: '' });
-    form.setValue('name', '', { shouldDirty: true });
+    form.setValue(
+      'name',
+      getCalendarExportNameAfterOrgChange({
+        currentName: form.getValues('name'),
+        isEditingExistingExport: Boolean(props.exportToEdit),
+      }),
+      { shouldDirty: true }
+    );
     setSelectedTemplateId('custom');
   };
 

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -352,8 +352,9 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
 
   const save = async (values: FormValues) => {
     if (props.mode === 'personal' && props.onSavePersonal) {
+      let result: SavedExport | void;
       try {
-        await props.onSavePersonal({
+        result = await props.onSavePersonal({
           id: props.exportToEdit?.id,
           orgId: values.orgId,
           name: values.name,
@@ -363,6 +364,10 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
         return;
       }
       form.reset(values);
+      if (result && !props.exportToEdit) {
+        setSavedExport(result);
+        return;
+      }
       props.onOpenChange(false);
       return;
     }

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -335,9 +335,8 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
 
   const save = async (values: FormValues) => {
     if (props.mode === 'personal' && props.onSavePersonal) {
-      let result: SavedExport | void;
       try {
-        result = await props.onSavePersonal({
+        await props.onSavePersonal({
           id: props.exportToEdit?.id,
           orgId: values.orgId,
           name: values.name,
@@ -346,10 +345,8 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
       } catch {
         return;
       }
-      if (result) {
-        setSavedExport(result);
-      }
       form.reset(values);
+      props.onOpenChange(false);
       return;
     }
 

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -101,6 +101,12 @@ const steps = [
   { id: 'preview', label: 'Vorschau' },
 ] as const;
 
+const calendarExportInstructions = [
+  'Kopieren Sie die URL oder klicken Sie auf "In Kalender öffnen".',
+  'Fügen Sie die URL in Ihrer Kalender-App als Abonnement hinzu.',
+  'Ihr Kalender synchronisiert automatisch alle Ereignisse.',
+];
+
 function getInitialStepIndex(input: {
   exportToEdit?: CalendarExport | null;
   templateToEdit?: CalendarExportTemplateChoice | null;
@@ -455,12 +461,13 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
   };
 
   const step = steps[stepIndex];
+  const dialogTitle = savedExport ? 'Kalender-Link ist bereit' : step.label;
 
   return (
     <Dialog open={props.open} onOpenChange={requestClose}>
       <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{step.label}</DialogTitle>
+          <DialogTitle>{dialogTitle}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-3">
@@ -470,7 +477,7 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
                 key={item.id}
                 className={cn(
                   'h-1 flex-1 rounded-full',
-                  index <= stepIndex ? 'bg-primary' : 'bg-muted'
+                  savedExport || index <= stepIndex ? 'bg-primary' : 'bg-muted'
                 )}
                 aria-label={item.label}
               />
@@ -761,7 +768,48 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
             </div>
           )}
 
-          {step.id === 'preview' && (
+          {savedExport ? (
+            <div className="space-y-5">
+              <div className="space-y-3 rounded-md bg-muted/50 p-4">
+                <p className="font-medium">So funktioniert&apos;s</p>
+                <div className="space-y-3">
+                  {calendarExportInstructions.map((instruction, index) => (
+                    <div key={instruction} className="flex items-center gap-3">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium">
+                        {index + 1}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {instruction}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-3 rounded-md border p-3">
+                <p className="font-medium">Neuer Kalenderexport-Link</p>
+                <p className="text-muted-foreground font-mono text-xs break-all">
+                  {savedExport.webcalUrl}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => copyUrl(savedExport.webcalUrl)}
+                  >
+                    <Copy className="mr-2 h-4 w-4" />
+                    Kopieren
+                  </Button>
+                  <Button type="button" variant="outline" asChild>
+                    <a href={savedExport.webcalUrl}>
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      In Kalender öffnen
+                    </a>
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : step.id === 'preview' && (
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="calendar-export-name">
@@ -898,53 +946,31 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
               <p className="text-muted-foreground text-sm">
                 {selectedOrg?.name} · {modeLabel(config.mode)}
               </p>
-              {savedExport ? (
-                <div className="space-y-3 rounded-md border p-3">
-                  <p className="font-medium">Kalender-Link ist bereit</p>
-                  <p className="text-muted-foreground font-mono text-xs break-all">
-                    {savedExport.webcalUrl}
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => copyUrl(savedExport.webcalUrl)}
-                    >
-                      <Copy className="mr-2 h-4 w-4" />
-                      Kopieren
-                    </Button>
-                    <Button type="button" variant="outline" asChild>
-                      <a href={savedExport.webcalUrl}>
-                        <ExternalLink className="mr-2 h-4 w-4" />
-                        In Kalender öffnen
-                      </a>
-                    </Button>
-                  </div>
-                </div>
-              ) : null}
             </div>
           )}
 
           <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() =>
-                stepIndex === 0
-                  ? requestClose(false)
-                  : setStepIndex((current) => current - 1)
-              }
-            >
-              {stepIndex === 0 ? 'Abbrechen' : 'Zurück'}
-            </Button>
             {savedExport ? (
               <Button type="button" onClick={() => props.onOpenChange(false)}>
                 Schließen
               </Button>
             ) : (
-              <Button type="submit">
-                {stepIndex === steps.length - 1 ? 'Speichern' : 'Weiter'}
-              </Button>
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    stepIndex === 0
+                      ? requestClose(false)
+                      : setStepIndex((current) => current - 1)
+                  }
+                >
+                  {stepIndex === 0 ? 'Abbrechen' : 'Zurück'}
+                </Button>
+                <Button type="submit">
+                  {stepIndex === steps.length - 1 ? 'Speichern' : 'Weiter'}
+                </Button>
+              </>
             )}
           </DialogFooter>
         </form>

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 import { MultiSelect } from '@/components/form/multi-select';
 import { TimeTextInput } from '@/components/form/TimeTextInput';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -43,6 +44,7 @@ import {
   type CalendarExportEligibility,
 } from '@/features/calendar-subscription/hooks/useCalendarSubscription';
 import { cn } from '@/lib/utils';
+import { getPreviewDurationTag } from './CalendarExportDialog.utils';
 
 const formSchema = z.object({
   orgId: z.string().uuid(),
@@ -846,14 +848,29 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
                   </p>
                 ) : previewQuery.data?.previewEvents.length ? (
                   <div className="divide-y">
-                    {previewQuery.data.previewEvents.map((event) => (
-                      <div key={event.id} className="py-2 first:pt-0 last:pb-0">
-                        <p className="font-medium">{event.title}</p>
-                        <p className="text-muted-foreground text-sm">
-                          {formatPreviewDate(event)}
-                        </p>
-                      </div>
-                    ))}
+                    {previewQuery.data.previewEvents.map((event) => {
+                      const durationTag = getPreviewDurationTag(event);
+
+                      return (
+                        <div
+                          key={event.id}
+                          className="relative py-2 pr-24 first:pt-0 last:pb-0"
+                        >
+                          <p className="font-medium">{event.title}</p>
+                          <p className="text-muted-foreground text-sm">
+                            {formatPreviewDate(event)}
+                          </p>
+                          {durationTag ? (
+                            <Badge
+                              variant="secondary"
+                              className="absolute top-2 right-0"
+                            >
+                              {durationTag}
+                            </Badge>
+                          ) : null}
+                        </div>
+                      );
+                    })}
                   </div>
                 ) : (
                   <p className="text-muted-foreground text-sm">

--- a/src/components/settings/userProfile/CalendarExportDialog.tsx
+++ b/src/components/settings/userProfile/CalendarExportDialog.tsx
@@ -52,6 +52,7 @@ const formSchema = z.object({
 });
 
 type FormValues = z.infer<typeof formSchema>;
+type FormInputValues = z.input<typeof formSchema>;
 type SavedExport = {
   name: string;
   webcalUrl: string;
@@ -173,6 +174,15 @@ function formatPreviewDate(input: {
   })}`;
 }
 
+function selectedTitlePartCount(config: CalendarExportConfig) {
+  return [
+    config.titleAdditions.assignedHelperNames,
+    config.titleAdditions.eventTitle,
+    config.titleAdditions.categories,
+    config.titleAdditions.helperCount,
+  ].filter(Boolean).length;
+}
+
 export function CalendarExportDialog(props: CalendarExportDialogProps) {
   const { eligibility, exportToEdit, initialOrgId, open, templateToEdit } =
     props;
@@ -186,7 +196,7 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
   }>({ from: null, to: null });
   const { showDestructive } = useConfirmDialog();
 
-  const form = useForm<FormValues>({
+  const form = useForm<FormInputValues, unknown, FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: buildInitialValues({
       eligibility,
@@ -197,7 +207,8 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
   });
 
   const orgId = useWatch({ control: form.control, name: 'orgId' });
-  const config = useWatch({ control: form.control, name: 'config' });
+  const watchedConfig = useWatch({ control: form.control, name: 'config' });
+  const config = calendarExportConfigSchema.parse(watchedConfig);
   const selectedEligibility = props.eligibility.find(
     (item) => item.organization.id === orgId
   );
@@ -208,6 +219,7 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
     props.mode === 'personal' ? orgId : null
   );
   const previewQuery = useCalendarExportPreview(orgId, config);
+  const titlePartCount = selectedTitlePartCount(config);
 
   const availableModes = selectedEligibility?.modes ?? (['helper'] as const);
 
@@ -759,10 +771,46 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
               )}
 
               <div className="space-y-3">
-                <Label>Titel-Zusätze</Label>
+                <Label>Titel zusammensetzen aus</Label>
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.titleAdditions.assignedHelperNames}
+                    disabled={
+                      config.titleAdditions.assignedHelperNames &&
+                      titlePartCount === 1
+                    }
+                    onCheckedChange={(checked) =>
+                      form.setValue(
+                        'config.titleAdditions.assignedHelperNames',
+                        checked === true,
+                        { shouldDirty: true }
+                      )
+                    }
+                  />
+                  <span>Eingeteilte Personen</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={config.titleAdditions.eventTitle}
+                    disabled={
+                      config.titleAdditions.eventTitle && titlePartCount === 1
+                    }
+                    onCheckedChange={(checked) =>
+                      form.setValue(
+                        'config.titleAdditions.eventTitle',
+                        checked === true,
+                        { shouldDirty: true }
+                      )
+                    }
+                  />
+                  <span>Einsatztitel</span>
+                </label>
                 <label className="flex items-center gap-2">
                   <Checkbox
                     checked={config.titleAdditions.categories}
+                    disabled={
+                      config.titleAdditions.categories && titlePartCount === 1
+                    }
                     onCheckedChange={(checked) =>
                       form.setValue(
                         'config.titleAdditions.categories',
@@ -776,6 +824,9 @@ export function CalendarExportDialog(props: CalendarExportDialogProps) {
                 <label className="flex items-center gap-2">
                   <Checkbox
                     checked={config.titleAdditions.helperCount}
+                    disabled={
+                      config.titleAdditions.helperCount && titlePartCount === 1
+                    }
                     onCheckedChange={(checked) =>
                       form.setValue(
                         'config.titleAdditions.helperCount',

--- a/src/components/settings/userProfile/CalendarExportDialog.utils.test.ts
+++ b/src/components/settings/userProfile/CalendarExportDialog.utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getPreviewDurationTag } from './CalendarExportDialog.utils';
+import {
+  getCalendarExportNameAfterOrgChange,
+  getPreviewDurationTag,
+} from './CalendarExportDialog.utils';
 
 describe('getPreviewDurationTag', () => {
   it('returns no tag for same-day events', () => {
@@ -27,5 +30,25 @@ describe('getPreviewDurationTag', () => {
         end: '2025-09-25T06:44:00.000Z',
       })
     ).toBe('22 Tage');
+  });
+});
+
+describe('getCalendarExportNameAfterOrgChange', () => {
+  it('keeps the current name when editing an existing export', () => {
+    expect(
+      getCalendarExportNameAfterOrgChange({
+        currentName: 'Nur eigene in der Zukunft',
+        isEditingExistingExport: true,
+      })
+    ).toBe('Nur eigene in der Zukunft');
+  });
+
+  it('clears the name when creating a new export', () => {
+    expect(
+      getCalendarExportNameAfterOrgChange({
+        currentName: 'Nur eigene in der Zukunft',
+        isEditingExistingExport: false,
+      })
+    ).toBe('');
   });
 });

--- a/src/components/settings/userProfile/CalendarExportDialog.utils.test.ts
+++ b/src/components/settings/userProfile/CalendarExportDialog.utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getPreviewDurationTag } from './CalendarExportDialog.utils';
+
+describe('getPreviewDurationTag', () => {
+  it('returns no tag for same-day events', () => {
+    expect(
+      getPreviewDurationTag({
+        start: '2025-09-03T05:44:00.000Z',
+        end: '2025-09-03T06:44:00.000Z',
+      })
+    ).toBeNull();
+  });
+
+  it('returns a singular day tag for events spanning one calendar day', () => {
+    expect(
+      getPreviewDurationTag({
+        start: '2025-09-03T05:44:00.000Z',
+        end: '2025-09-04T06:44:00.000Z',
+      })
+    ).toBe('1 Tag');
+  });
+
+  it('returns the number of calendar days for multi-day events', () => {
+    expect(
+      getPreviewDurationTag({
+        start: '2025-09-03T05:44:00.000Z',
+        end: '2025-09-25T06:44:00.000Z',
+      })
+    ).toBe('22 Tage');
+  });
+});

--- a/src/components/settings/userProfile/CalendarExportDialog.utils.ts
+++ b/src/components/settings/userProfile/CalendarExportDialog.utils.ts
@@ -17,3 +17,10 @@ export function getPreviewDurationTag(input: { start: string; end: string }) {
 
   return days === 1 ? '1 Tag' : `${days} Tage`;
 }
+
+export function getCalendarExportNameAfterOrgChange(input: {
+  currentName: string;
+  isEditingExistingExport: boolean;
+}) {
+  return input.isEditingExistingExport ? input.currentName : '';
+}

--- a/src/components/settings/userProfile/CalendarExportDialog.utils.ts
+++ b/src/components/settings/userProfile/CalendarExportDialog.utils.ts
@@ -1,0 +1,19 @@
+export function getPreviewDurationTag(input: { start: string; end: string }) {
+  const start = new Date(input.start);
+  const end = new Date(input.end);
+  const startDay = new Date(
+    start.getFullYear(),
+    start.getMonth(),
+    start.getDate()
+  );
+  const endDay = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+  const days = Math.round(
+    (endDay.getTime() - startDay.getTime()) / (24 * 60 * 60 * 1000)
+  );
+
+  if (days <= 0) {
+    return null;
+  }
+
+  return days === 1 ? '1 Tag' : `${days} Tage`;
+}

--- a/src/components/settings/userProfile/CalendarIntegrationCard.tsx
+++ b/src/components/settings/userProfile/CalendarIntegrationCard.tsx
@@ -439,7 +439,7 @@ export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
         exportToEdit={editExport}
         onOpenChange={setDialogOpen}
         onSavePersonal={async (input) => {
-          if (input.id && input.orgId === editExport?.orgId) {
+          if (input.id) {
             const result = await calendarExports.updateExport.mutateAsync({
               id: input.id,
               orgId: input.orgId,

--- a/src/components/settings/userProfile/CalendarIntegrationCard.tsx
+++ b/src/components/settings/userProfile/CalendarIntegrationCard.tsx
@@ -9,7 +9,6 @@ import {
   Pencil,
   Play,
   Plus,
-  RefreshCw,
   Trash2,
 } from 'lucide-react';
 import Image from 'next/image';
@@ -390,6 +389,7 @@ export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
                         <Copy className="mr-2 h-4 w-4" />
                         Link kopieren
                       </DropdownMenuItem>
+                      {/*
                       <DropdownMenuItem
                         onClick={() =>
                           calendarExports.rotate.mutate(calendarExport.id)
@@ -398,6 +398,7 @@ export function CalendarIntegrationCard({ org }: CalendarIntegrationCardProps) {
                         <RefreshCw className="mr-2 h-4 w-4" />
                         Link neu generieren
                       </DropdownMenuItem>
+                      */}
                       <DropdownMenuItem
                         onClick={() =>
                           calendarExports.setActive.mutate({

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -507,8 +507,16 @@ export async function getCalendarExportPreviewAction(
         },
       },
       einsatz_helper: {
+        orderBy: {
+          joined_at: 'asc',
+        },
         select: {
           user_id: true,
+          user: {
+            select: {
+              firstname: true,
+            },
+          },
         },
       },
     },
@@ -530,6 +538,9 @@ export async function getCalendarExportPreviewAction(
         categoryAbbreviations: event.einsatz_to_category
           .map((category) => category.einsatz_category.abbreviation)
           .filter((abbreviation) => abbreviation !== ''),
+        assignedHelperFirstNames: event.einsatz_helper.map(
+          (helper) => helper.user.firstname
+        ),
         assignedHelpers: event.einsatz_helper.length,
         helpersNeeded: event.helpers_needed,
         config: parsedConfig,

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -35,6 +35,10 @@ const exportInputSchema = z.object({
   config: calendarExportConfigSchema,
 });
 
+const exportUpdateInputSchema = exportInputSchema.extend({
+  orgId: z.string().uuid('Die Organisation ist ungültig.'),
+});
+
 const templateInputSchema = exportInputSchema.extend({
   description: z.string().trim().optional().nullable(),
 });
@@ -293,7 +297,7 @@ export async function createCalendarExportAction(
 
 export async function updateCalendarExportAction(
   id: string,
-  input: z.input<typeof exportInputSchema>
+  input: z.input<typeof exportUpdateInputSchema>
 ) {
   const session = await checkUserSession();
   const existing = await prisma.calendar_subscription.findFirst({
@@ -306,13 +310,15 @@ export async function updateCalendarExportAction(
   }
 
   await assertReadAccess(existing.org_id);
-  const parsedInput = exportInputSchema.parse(input);
-  await assertModeAccess(existing.org_id, parsedInput.config.mode);
-  await validateConfigReferences(existing.org_id, parsedInput.config);
+  const parsedInput = exportUpdateInputSchema.parse(input);
+  await assertReadAccess(parsedInput.orgId);
+  await assertModeAccess(parsedInput.orgId, parsedInput.config.mode);
+  await validateConfigReferences(parsedInput.orgId, parsedInput.config);
 
   const calendarExport = await updateCalendarExport({
     id,
     userId: session.user.id,
+    orgId: parsedInput.orgId,
     name: parsedInput.name,
     config: parsedInput.config,
   });

--- a/src/features/calendar-subscription/actions.ts
+++ b/src/features/calendar-subscription/actions.ts
@@ -515,6 +515,7 @@ export async function getCalendarExportPreviewAction(
           user: {
             select: {
               firstname: true,
+              lastname: true,
             },
           },
         },
@@ -538,9 +539,10 @@ export async function getCalendarExportPreviewAction(
         categoryAbbreviations: event.einsatz_to_category
           .map((category) => category.einsatz_category.abbreviation)
           .filter((abbreviation) => abbreviation !== ''),
-        assignedHelperFirstNames: event.einsatz_helper.map(
-          (helper) => helper.user.firstname
-        ),
+        assignedHelperNames: event.einsatz_helper.map((helper) => ({
+          firstname: helper.user.firstname,
+          lastname: helper.user.lastname,
+        })),
         assignedHelpers: event.einsatz_helper.length,
         helpersNeeded: event.helpers_needed,
         config: parsedConfig,

--- a/src/features/calendar-subscription/calendarSubscription.test.ts
+++ b/src/features/calendar-subscription/calendarSubscription.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultCalendarExportConfig } from './config';
+
+const { mockFindFirst, mockFindMany, mockUpdate } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    calendar_subscription: {
+      findFirst: mockFindFirst,
+      findMany: mockFindMany,
+      update: mockUpdate,
+    },
+  },
+}));
+
+import { updateCalendarExport } from './calendarSubscription';
+
+describe('calendar subscription dal', () => {
+  beforeEach(() => {
+    mockFindFirst.mockReset();
+    mockFindMany.mockReset();
+    mockUpdate.mockReset();
+  });
+
+  it('verschiebt einen bestehenden Kalenderexport beim Bearbeiten in die neue Organisation', async () => {
+    mockFindFirst.mockResolvedValue({ org_id: 'old-org' });
+    mockFindMany.mockResolvedValue([]);
+    mockUpdate.mockResolvedValue({
+      id: 'export-1',
+      user_id: 'user-1',
+      org_id: 'new-org',
+      name: 'Mein Export',
+      config: defaultCalendarExportConfig,
+    });
+
+    await updateCalendarExport({
+      id: 'export-1',
+      userId: 'user-1',
+      orgId: 'new-org',
+      name: ' Mein Export ',
+      config: defaultCalendarExportConfig,
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        user_id: 'user-1',
+        org_id: 'new-org',
+        id: { not: 'export-1' },
+      },
+      select: { name: true },
+    });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'export-1', user_id: 'user-1' },
+      data: {
+        org_id: 'new-org',
+        name: 'Mein Export',
+        config: defaultCalendarExportConfig,
+      },
+    });
+  });
+});

--- a/src/features/calendar-subscription/calendarSubscription.ts
+++ b/src/features/calendar-subscription/calendarSubscription.ts
@@ -140,6 +140,7 @@ export async function createCalendarExport(input: {
 export async function updateCalendarExport(input: {
   id: string;
   userId: string;
+  orgId: string;
   name: string;
   config: CalendarExportConfig;
 }) {
@@ -156,7 +157,7 @@ export async function updateCalendarExport(input: {
   if (
     await calendarExportNameExists({
       userId: input.userId,
-      orgId: existing.org_id,
+      orgId: input.orgId,
       name: trimmedName,
       excludeId: input.id,
     })
@@ -167,6 +168,7 @@ export async function updateCalendarExport(input: {
   return prisma.calendar_subscription.update({
     where: { id: input.id, user_id: input.userId },
     data: {
+      org_id: input.orgId,
       name: trimmedName,
       config: toJsonInput(input.config),
     },

--- a/src/features/calendar-subscription/config.test.ts
+++ b/src/features/calendar-subscription/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseCalendarExportConfig } from './config';
+
+describe('parseCalendarExportConfig', () => {
+  it('fills new title settings for existing calendar export configs', () => {
+    expect(
+      parseCalendarExportConfig({
+        version: 1,
+        mode: 'helper',
+        categoryIds: [],
+        statusIds: [],
+        statusPseudo: [],
+        timeWindow: null,
+        includeAllDay: true,
+        futureOnly: false,
+        titleAdditions: {
+          categories: true,
+          helperCount: true,
+        },
+      }).titleAdditions
+    ).toEqual({
+      eventTitle: true,
+      assignedHelperNames: false,
+      categories: true,
+      helperCount: true,
+    });
+  });
+});

--- a/src/features/calendar-subscription/config.ts
+++ b/src/features/calendar-subscription/config.ts
@@ -8,6 +8,8 @@ export type CalendarExportStatusPseudo =
   (typeof calendarExportStatusPseudoValues)[number];
 
 export const calendarExportTitleAdditionKeys = [
+  'eventTitle',
+  'assignedHelperNames',
   'categories',
   'helperCount',
 ] as const;
@@ -15,6 +17,18 @@ export type CalendarExportTitleAdditionKey =
   (typeof calendarExportTitleAdditionKeys)[number];
 
 const normalizedTimeSchema = z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/);
+const defaultCalendarExportTitleAdditions = {
+  eventTitle: true,
+  assignedHelperNames: false,
+  categories: true,
+  helperCount: true,
+};
+const calendarExportTitleAdditionsSchema = z.object({
+  eventTitle: z.boolean(),
+  assignedHelperNames: z.boolean(),
+  categories: z.boolean(),
+  helperCount: z.boolean(),
+});
 
 export const calendarExportConfigSchema = z
   .object({
@@ -31,10 +45,19 @@ export const calendarExportConfigSchema = z
       .nullable(),
     includeAllDay: z.boolean(),
     futureOnly: z.boolean(),
-    titleAdditions: z.object({
-      categories: z.boolean(),
-      helperCount: z.boolean(),
-    }),
+    titleAdditions: z
+      .object({
+        eventTitle: z.boolean().optional(),
+        assignedHelperNames: z.boolean().optional(),
+        categories: z.boolean().optional(),
+        helperCount: z.boolean().optional(),
+      })
+      .transform((titleAdditions) =>
+        calendarExportTitleAdditionsSchema.parse({
+          ...defaultCalendarExportTitleAdditions,
+          ...titleAdditions,
+        })
+      ),
   })
   .transform((config) =>
     config.mode === 'verwaltung'
@@ -57,8 +80,7 @@ export const defaultCalendarExportConfig: CalendarExportConfig = {
   includeAllDay: true,
   futureOnly: false,
   titleAdditions: {
-    categories: true,
-    helperCount: true,
+    ...defaultCalendarExportTitleAdditions,
   },
 };
 

--- a/src/features/calendar-subscription/filter.ts
+++ b/src/features/calendar-subscription/filter.ts
@@ -11,12 +11,14 @@ export type CalendarExportFilterEvent = {
     category_id?: string;
     einsatz_category?: {
       id?: string;
+      abbreviation?: string;
     };
   }>;
   einsatz_helper: Array<{
     user_id?: string;
     user?: {
       id?: string;
+      firstname?: string;
     };
   }>;
 };

--- a/src/features/calendar-subscription/filter.ts
+++ b/src/features/calendar-subscription/filter.ts
@@ -19,6 +19,7 @@ export type CalendarExportFilterEvent = {
     user?: {
       id?: string;
       firstname?: string;
+      lastname?: string;
     };
   }>;
 };

--- a/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
+++ b/src/features/calendar-subscription/hooks/useCalendarSubscription.ts
@@ -84,10 +84,11 @@ export function useCalendarExports() {
   const updateExport = useMutation({
     mutationFn: ({
       id,
+      orgId,
       name,
       config,
     }: CalendarExportMutationInput & { id: string }) =>
-      updateCalendarExportAction(id, { name, config }),
+      updateCalendarExportAction(id, { orgId, name, config }),
     onSuccess: async () => {
       await invalidateExports();
       toast.success('Kalenderexport wurde gespeichert');

--- a/src/features/calendar-subscription/title.test.ts
+++ b/src/features/calendar-subscription/title.test.ts
@@ -2,13 +2,17 @@ import { describe, expect, it } from 'vitest';
 import { defaultCalendarExportConfig } from './config';
 import { composeCalendarExportEventTitle } from './title';
 
+function helper(firstname: string, lastname = 'Muster') {
+  return { firstname, lastname };
+}
+
 describe('composeCalendarExportEventTitle', () => {
   it('joins categories and helper count in one bracket group', () => {
     expect(
       composeCalendarExportEventTitle({
         title: 'Führung',
         categoryAbbreviations: ['DA', 'VA'],
-        assignedHelperFirstNames: ['Erika'],
+        assignedHelperNames: [helper('Erika')],
         assignedHelpers: 1,
         helpersNeeded: 2,
         config: defaultCalendarExportConfig,
@@ -21,7 +25,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Führung',
         categoryAbbreviations: ['DA'],
-        assignedHelperFirstNames: [],
+        assignedHelperNames: [],
         assignedHelpers: 0,
         helpersNeeded: 0,
         config: defaultCalendarExportConfig,
@@ -34,7 +38,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Führung',
         categoryAbbreviations: ['DA'],
-        assignedHelperFirstNames: ['Erika'],
+        assignedHelperNames: [helper('Erika')],
         assignedHelpers: 1,
         helpersNeeded: 2,
         config: {
@@ -55,7 +59,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Kassa/Café',
         categoryAbbreviations: [],
-        assignedHelperFirstNames: ['Raphael'],
+        assignedHelperNames: [helper('Raphael')],
         assignedHelpers: 1,
         helpersNeeded: 2,
         config: {
@@ -74,7 +78,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Kassa/Café',
         categoryAbbreviations: [],
-        assignedHelperFirstNames: [],
+        assignedHelperNames: [],
         assignedHelpers: 0,
         helpersNeeded: 2,
         config: {
@@ -95,7 +99,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Kassa/Café',
         categoryAbbreviations: [],
-        assignedHelperFirstNames: ['Luca'],
+        assignedHelperNames: [helper('Luca')],
         assignedHelpers: 1,
         helpersNeeded: 4,
         config: {
@@ -116,7 +120,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Kassa/Café',
         categoryAbbreviations: [],
-        assignedHelperFirstNames: ['Raphael', 'Luca'],
+        assignedHelperNames: [helper('Raphael'), helper('Luca')],
         assignedHelpers: 2,
         helpersNeeded: 3,
         config: {
@@ -137,7 +141,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Kassa/Café',
         categoryAbbreviations: [],
-        assignedHelperFirstNames: ['Raphael', 'Luca', 'Anna'],
+        assignedHelperNames: [helper('Raphael'), helper('Luca'), helper('Anna')],
         assignedHelpers: 3,
         helpersNeeded: 2,
         config: {
@@ -156,7 +160,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Kassa/Café',
         categoryAbbreviations: ['CA'],
-        assignedHelperFirstNames: ['Raphael'],
+        assignedHelperNames: [helper('Raphael')],
         assignedHelpers: 1,
         helpersNeeded: 2,
         config: {
@@ -170,5 +174,26 @@ describe('composeCalendarExportEventTitle', () => {
         },
       })
     ).toBe('Kassa/Café');
+  });
+
+  it('uses the last name when the first name is blank', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: [],
+        assignedHelperNames: [helper('Raphael'), helper(' ', 'Huber')],
+        assignedHelpers: 2,
+        helpersNeeded: 2,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            eventTitle: false,
+            assignedHelperNames: true,
+            categories: false,
+            helperCount: false,
+          },
+        },
+      })
+    ).toBe('Raphael, Huber');
   });
 });

--- a/src/features/calendar-subscription/title.test.ts
+++ b/src/features/calendar-subscription/title.test.ts
@@ -8,6 +8,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Führung',
         categoryAbbreviations: ['DA', 'VA'],
+        assignedHelperFirstNames: ['Erika'],
         assignedHelpers: 1,
         helpersNeeded: 2,
         config: defaultCalendarExportConfig,
@@ -20,6 +21,7 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Führung',
         categoryAbbreviations: ['DA'],
+        assignedHelperFirstNames: [],
         assignedHelpers: 0,
         helpersNeeded: 0,
         config: defaultCalendarExportConfig,
@@ -32,16 +34,141 @@ describe('composeCalendarExportEventTitle', () => {
       composeCalendarExportEventTitle({
         title: 'Führung',
         categoryAbbreviations: ['DA'],
+        assignedHelperFirstNames: ['Erika'],
         assignedHelpers: 1,
         helpersNeeded: 2,
         config: {
           ...defaultCalendarExportConfig,
           titleAdditions: {
+            eventTitle: false,
+            assignedHelperNames: false,
             categories: false,
             helperCount: false,
           },
         },
       })
     ).toBe('Führung');
+  });
+
+  it('prepends assigned helper names and the number of open positions when enabled', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: [],
+        assignedHelperFirstNames: ['Raphael'],
+        assignedHelpers: 1,
+        helpersNeeded: 2,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            ...defaultCalendarExportConfig.titleAdditions,
+            assignedHelperNames: true,
+          },
+        },
+      })
+    ).toBe('Raphael + 1 | Kassa/Café (1/2)');
+  });
+
+  it('omits the helper name block when no helper is assigned', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: [],
+        assignedHelperFirstNames: [],
+        assignedHelpers: 0,
+        helpersNeeded: 2,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            eventTitle: false,
+            assignedHelperNames: true,
+            categories: false,
+            helperCount: false,
+          },
+        },
+      })
+    ).toBe('Kassa/Café');
+  });
+
+  it('uses one number for multiple open positions', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: [],
+        assignedHelperFirstNames: ['Luca'],
+        assignedHelpers: 1,
+        helpersNeeded: 4,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            eventTitle: false,
+            assignedHelperNames: true,
+            categories: false,
+            helperCount: false,
+          },
+        },
+      })
+    ).toBe('Luca + 3');
+  });
+
+  it('separates multiple assigned helper names with commas', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: [],
+        assignedHelperFirstNames: ['Raphael', 'Luca'],
+        assignedHelpers: 2,
+        helpersNeeded: 3,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            eventTitle: false,
+            assignedHelperNames: true,
+            categories: false,
+            helperCount: false,
+          },
+        },
+      })
+    ).toBe('Raphael, Luca + 1');
+  });
+
+  it('shows all assigned helpers when more helpers are assigned than needed', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: [],
+        assignedHelperFirstNames: ['Raphael', 'Luca', 'Anna'],
+        assignedHelpers: 3,
+        helpersNeeded: 2,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            ...defaultCalendarExportConfig.titleAdditions,
+            assignedHelperNames: true,
+          },
+        },
+      })
+    ).toBe('Raphael, Luca, Anna | Kassa/Café (3/2)');
+  });
+
+  it('falls back to the event title when all title parts are disabled', () => {
+    expect(
+      composeCalendarExportEventTitle({
+        title: 'Kassa/Café',
+        categoryAbbreviations: ['CA'],
+        assignedHelperFirstNames: ['Raphael'],
+        assignedHelpers: 1,
+        helpersNeeded: 2,
+        config: {
+          ...defaultCalendarExportConfig,
+          titleAdditions: {
+            eventTitle: false,
+            assignedHelperNames: false,
+            categories: false,
+            helperCount: false,
+          },
+        },
+      })
+    ).toBe('Kassa/Café');
   });
 });

--- a/src/features/calendar-subscription/title.ts
+++ b/src/features/calendar-subscription/title.ts
@@ -3,7 +3,10 @@ import type { CalendarExportConfig } from './config';
 export function composeCalendarExportEventTitle(input: {
   title: string;
   categoryAbbreviations: string[];
-  assignedHelperFirstNames: string[];
+  assignedHelperNames: Array<{
+    firstname: string;
+    lastname: string;
+  }>;
   assignedHelpers: number;
   helpersNeeded: number;
   config: CalendarExportConfig;
@@ -12,10 +15,13 @@ export function composeCalendarExportEventTitle(input: {
   const additions: string[] = [];
 
   if (input.config.titleAdditions.assignedHelperNames) {
-    const helperNames = input.assignedHelperFirstNames
-      .map((name) => name.trim())
+    const helperNames = input.assignedHelperNames
+      .map((helper) => helper.firstname.trim() || helper.lastname.trim())
       .filter(Boolean);
-    const openPositions = Math.max(input.helpersNeeded - helperNames.length, 0);
+    const openPositions = Math.max(
+      input.helpersNeeded - input.assignedHelpers,
+      0
+    );
     if (helperNames.length > 0) {
       const helperNameText =
         openPositions > 0

--- a/src/features/calendar-subscription/title.ts
+++ b/src/features/calendar-subscription/title.ts
@@ -3,11 +3,31 @@ import type { CalendarExportConfig } from './config';
 export function composeCalendarExportEventTitle(input: {
   title: string;
   categoryAbbreviations: string[];
+  assignedHelperFirstNames: string[];
   assignedHelpers: number;
   helpersNeeded: number;
   config: CalendarExportConfig;
 }) {
+  const titleParts: string[] = [];
   const additions: string[] = [];
+
+  if (input.config.titleAdditions.assignedHelperNames) {
+    const helperNames = input.assignedHelperFirstNames
+      .map((name) => name.trim())
+      .filter(Boolean);
+    const openPositions = Math.max(input.helpersNeeded - helperNames.length, 0);
+    if (helperNames.length > 0) {
+      const helperNameText =
+        openPositions > 0
+          ? `${helperNames.join(', ')} + ${openPositions}`
+          : helperNames.join(', ');
+      titleParts.push(helperNameText);
+    }
+  }
+
+  if (input.config.titleAdditions.eventTitle) {
+    titleParts.push(input.title);
+  }
 
   if (input.config.titleAdditions.categories) {
     const categoryText = input.categoryAbbreviations
@@ -24,9 +44,20 @@ export function composeCalendarExportEventTitle(input: {
     additions.push(`${input.assignedHelpers}/${input.helpersNeeded}`);
   }
 
-  return additions.length > 0
-    ? `${input.title} (${additions.join(' · ')})`
-    : input.title;
+  const baseTitle = titleParts.join(' | ');
+  if (baseTitle && additions.length > 0) {
+    return `${baseTitle} (${additions.join(' · ')})`;
+  }
+
+  if (baseTitle) {
+    return baseTitle;
+  }
+
+  if (additions.length > 0) {
+    return additions.join(' · ');
+  }
+
+  return input.title;
 }
 
 export function slugifyCalendarExportFilenamePart(value: string) {


### PR DESCRIPTION
This pull request introduces several improvements and new features to the calendar export functionality, focusing on enhanced customization of event titles, improved UI/UX in the calendar export dialog, and expanded backend support for updating exports (including moving them between organizations). There are also new tests and utility functions to support these changes.

**Calendar Export Title Customization and Display:**

* Added a new option to include assigned helper names in calendar export event titles, and ensured these names are correctly passed and displayed in both the backend (`route.ts`, actions) and frontend preview (`CalendarExportDialog.tsx`). ([src/app/api/calendar/[token]/route.tsR384-R386](diffhunk://#diff-5662a39cfb10f3dda168138737979fea6cc8643702577788292f61e0a35793fbR384-R386), [src/features/calendar-subscription/actions.tsR541-R543](diffhunk://#diff-22e3eaab9a300fb8b807be13ccb1d526a0d61f68b5271f9df5e284a1c84af0e2R541-R543), [src/app/api/calendar/[token]/route.test.tsR170-R259](diffhunk://#diff-5b710701b43083ce3718992705a7d203e09b762875b30bf37a4e9fd32aaecb33R170-R259))
* Updated the UI in `CalendarExportDialog` to allow users to flexibly compose event titles from multiple parts (assigned helpers, event title, categories, helper count), with logic to prevent all options from being deselected. [[1]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cL765-R815) [[2]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cR829-R831)
* The backend now orders assigned helpers by their join date when exporting and previewing calendar events, ensuring consistent display order. ([src/app/api/calendar/[token]/route.tsR158-R160](diffhunk://#diff-5662a39cfb10f3dda168138737979fea6cc8643702577788292f61e0a35793fbR158-R160), [src/features/calendar-subscription/actions.tsR510-R519](diffhunk://#diff-22e3eaab9a300fb8b807be13ccb1d526a0d61f68b5271f9df5e284a1c84af0e2R510-R519))

**UI/UX Improvements in Calendar Export Dialog:**

* Added a duration badge to event previews, showing the number of days for multi-day events using the new `getPreviewDurationTag` utility (with tests). [[1]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cL801-R873) [[2]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cR47) [[3]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cR11) [[4]](diffhunk://#diff-29b90c19d90776363f0f4d69ce56b961eaa9689afa49cf0b4272277e4974c054R1-R31) [[5]](diffhunk://#diff-629f70cb08fd21877cc6a0be644526c1ecfd4f135867fc1390773b410d1e1436R1-R19)
* Improved form handling and type safety in the export dialog, including better reset and close logic after saving, and stricter config parsing. [[1]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cR57) [[2]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cL189-R201) [[3]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cL200-R213) [[4]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cL338-R353) [[5]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cL349-R363) [[6]](diffhunk://#diff-0014a6ff752c358fcfb4a26e67df8f9a48f18c6f9b532426e57a490be631349cR224)

**Backend and Data Model Enhancements:**

* The update action for calendar exports now supports changing the organization (`orgId`) of an existing export, with validation and correct data propagation. [[1]](diffhunk://#diff-22e3eaab9a300fb8b807be13ccb1d526a0d61f68b5271f9df5e284a1c84af0e2R38-R41) [[2]](diffhunk://#diff-22e3eaab9a300fb8b807be13ccb1d526a0d61f68b5271f9df5e284a1c84af0e2L296-R300) [[3]](diffhunk://#diff-22e3eaab9a300fb8b807be13ccb1d526a0d61f68b5271f9df5e284a1c84af0e2L309-R321)
* Added a test to ensure that updating a calendar export correctly moves it to a new organization in the data layer.

**Testing and Utilities:**

* Added new tests for the duration tag utility and for moving calendar exports between organizations. [[1]](diffhunk://#diff-29b90c19d90776363f0f4d69ce56b961eaa9689afa49cf0b4272277e4974c054R1-R31) [[2]](diffhunk://#diff-ea9a320cad535819608b5cd733e9a428d0f575593527ebf5b862485f2f075622R1-R65)
* Introduced a utility function `getPreviewDurationTag` to compute and display event duration badges.

These changes collectively provide a more flexible, user-friendly, and robust calendar export experience.